### PR TITLE
Use client.close during server shutdown

### DIFF
--- a/src/notebooklm_mcp/server.py
+++ b/src/notebooklm_mcp/server.py
@@ -271,7 +271,7 @@ class NotebookLMFastMCP:
         """Gracefully stop the server"""
         try:
             if self.client:
-                await self.client.stop()
+                await self.client.close()
                 logger.info("✅ FastMCP server stopped gracefully")
         except Exception as e:
             logger.error(f"Error during server shutdown: {e}")


### PR DESCRIPTION
## Summary
- call `NotebookLMClient.close()` when stopping the server to avoid AttributeError
- update the FastMCP comprehensive tests to mock the new close call and verify shutdown
- switch the async FastMCP server fixture to `pytest_asyncio.fixture`

## Testing
- PYTHONPATH=src pytest tests/test_fastmcp_comprehensive.py::TestFastMCPServer::test_server_stop_closes_client


------
https://chatgpt.com/codex/tasks/task_e_68ca849bf8688321889541253d3fd346