### PR TITLE
Improve NotebookLM MCP monitoring and remote security

### DIFF
--- a/src/notebooklm_mcp/monitoring.py
+++ b/src/notebooklm_mcp/monitoring.py
@@ -268,9 +268,12 @@ async def periodic_health_check(interval: int = 30) -> None:
 def setup_logging(debug: bool = False) -> None:
     """Setup structured logging"""
     import sys
+    from pathlib import Path
 
     # Remove default handler
     logger.remove()
+
+    Path("logs").mkdir(parents=True, exist_ok=True)
 
     # Add structured logging
     log_format = (

--- a/src/notebooklm_mcp/security.py
+++ b/src/notebooklm_mcp/security.py
@@ -1,0 +1,74 @@
+"""Security middleware for NotebookLM MCP server."""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional, Sequence
+
+from loguru import logger
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+from .monitoring import metrics_collector
+
+
+class APIKeyMiddleware(BaseHTTPMiddleware):
+    """Starlette middleware enforcing API key authentication."""
+
+    def __init__(
+        self,
+        app,
+        *,
+        api_keys: Iterable[str],
+        header: str = "x-api-key",
+        allow_bearer: bool = True,
+        exempt_paths: Optional[Sequence[str]] = None,
+    ) -> None:
+        super().__init__(app)
+        self._api_keys = {key.strip() for key in api_keys if key and key.strip()}
+        self._header = (header or "x-api-key").strip() or "x-api-key"
+        self._allow_bearer = allow_bearer
+        self._exempt_paths = {
+            self._normalise_path(path)
+            for path in (exempt_paths or [])
+            if path is not None
+        }
+
+    @staticmethod
+    def _normalise_path(path: str) -> str:
+        cleaned = path.strip()
+        if not cleaned:
+            return "/"
+        if not cleaned.startswith("/"):
+            cleaned = f"/{cleaned}"
+        if cleaned != "/" and cleaned.endswith("/"):
+            cleaned = cleaned[:-1]
+        return cleaned
+
+    async def dispatch(self, request: Request, call_next) -> Response:  # type: ignore[override]
+        if request.method.upper() == "OPTIONS":
+            return await call_next(request)
+
+        path = self._normalise_path(str(request.url.path))
+        if path in self._exempt_paths:
+            return await call_next(request)
+
+        provided_key = request.headers.get(self._header)
+        if not provided_key and self._allow_bearer:
+            auth_header = request.headers.get("Authorization", "")
+            if auth_header.lower().startswith("bearer "):
+                provided_key = auth_header[7:]
+
+        if not provided_key or provided_key not in self._api_keys:
+            metrics_collector.record_auth_failure()
+            logger.warning("Rejected request with missing or invalid API key")
+            return JSONResponse(
+                {"detail": "Missing or invalid API key"},
+                status_code=401,
+                headers={"WWW-Authenticate": 'Bearer realm="NotebookLM MCP"'},
+            )
+
+        return await call_next(request)
+
+
+__all__ = ["APIKeyMiddleware"]

--- a/src/notebooklm_mcp/server.py
+++ b/src/notebooklm_mcp/server.py
@@ -5,15 +5,25 @@ Modern MCP server implementation using FastMCP v2 framework
 """
 
 import asyncio
+from contextlib import suppress
 from typing import Any, Dict, Optional
 
 from fastmcp import FastMCP
 from loguru import logger
 from pydantic import BaseModel, Field
+from starlette.middleware import Middleware
 
 from .client import NotebookLMClient
 from .config import ServerConfig
 from .exceptions import NotebookLMError
+from .monitoring import (
+    health_checker,
+    metrics_collector,
+    periodic_health_check,
+    request_timer,
+    setup_monitoring,
+)
+from .security import APIKeyMiddleware
 
 
 # Pydantic models for type-safe tool parameters
@@ -58,7 +68,16 @@ class NotebookLMFastMCP:
 
     def __init__(self, config: ServerConfig):
         self.config = config
-        self.client: Optional[NotebookLMClient] = None
+        self._client: Optional[NotebookLMClient] = None
+        self._health_task: Optional[asyncio.Task[None]] = None
+        self._metrics_started = False
+        self._request_semaphore = asyncio.Semaphore(
+            max(1, config.max_concurrent_requests)
+        )
+
+        # Reset monitoring state for new server instance
+        health_checker.client = None
+        metrics_collector.update_active_sessions(0)
 
         # Initialize FastMCP application
         self.app = FastMCP(name="NotebookLM MCP Server v2")
@@ -70,16 +89,83 @@ class NotebookLMFastMCP:
             f"FastMCP v2 server initialized for notebook: {config.default_notebook_id}"
         )
 
+    @property
+    def client(self) -> Optional[NotebookLMClient]:
+        return self._client
+
+    @client.setter
+    def client(self, value: Optional[NotebookLMClient]) -> None:
+        previous = getattr(self, "_client", None)
+        if previous is value:
+            return
+
+        self._client = value
+        health_checker.client = value
+
+        if value is None:
+            metrics_collector.update_active_sessions(0)
+            return
+
+        metrics_collector.update_active_sessions(1)
+
+        if previous is not None and previous is not value:
+            metrics_collector.record_browser_restart()
+
     async def _ensure_client(self) -> None:
         """Ensure NotebookLM client is initialized and authenticated"""
         try:
             if self.client is None:
-                self.client = NotebookLMClient(self.config)
-                await self.client.start()
+                new_client = NotebookLMClient(self.config)
+                self.client = new_client
+
+                try:
+                    await new_client.start()
+                except Exception:
+                    # Reset client state on failure so future retries can succeed
+                    self.client = None
+                    raise
+
                 logger.info("✅ NotebookLM client initialized and authenticated")
         except Exception as e:
             logger.error(f"Failed to initialize client: {e}")
             raise NotebookLMError(f"Client initialization failed: {e}")
+
+    def _start_background_tasks(self) -> None:
+        """Start monitoring and health check helpers"""
+
+        if self.config.enable_metrics and not self._metrics_started:
+            try:
+                setup_monitoring(self.config.metrics_port)
+                self._metrics_started = True
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.warning(
+                    "Unable to start Prometheus metrics server on port %s: %s",
+                    self.config.metrics_port,
+                    exc,
+                )
+
+        if not self.config.enable_health_checks:
+            return
+
+        if self._health_task is None or self._health_task.done():
+            self._health_task = asyncio.create_task(
+                periodic_health_check(self.config.health_check_interval)
+            )
+
+    async def _cleanup_background_tasks(self) -> None:
+        """Cancel background helpers"""
+
+        if self._health_task is None:
+            return
+
+        self._health_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await self._health_task
+        self._health_task = None
+
+    @staticmethod
+    def _is_local_host(host: str) -> bool:
+        return host in {"127.0.0.1", "localhost", "::1"}
 
     def _setup_tools(self) -> None:
         """Setup FastMCP v2 tools with enhanced error handling and performance"""
@@ -87,178 +173,310 @@ class NotebookLMFastMCP:
         @self.app.tool()
         async def healthcheck() -> Dict[str, Any]:
             """Check if the NotebookLM server is healthy and responsive."""
-            try:
-                if not self.client:
-                    return {
-                        "status": "unhealthy",
-                        "message": "Client not initialized",
-                        "authenticated": False,
-                    }
+            async with self._request_semaphore:
+                async with request_timer():
+                    try:
+                        health = await health_checker.check_health()
+                        system_info = {
+                            "uptime": health.uptime,
+                            "memory_usage": health.memory_usage,
+                            "cpu_usage": health.cpu_usage,
+                            "browser_status": health.browser_status,
+                        }
+                        metrics = metrics_collector.get_metrics()
 
-                auth_status = getattr(self.client, "_is_authenticated", False)
+                        try:
+                            client_present = bool(self.client)
+                            getattr(self.client, "_is_authenticated", None)
+                        except Exception as client_error:
+                            logger.error(
+                                "Health check client access failed: %s", client_error
+                            )
+                            return {
+                                "status": "error",
+                                "message": "Health check failed: client error",
+                                "authenticated": False,
+                                "notebook_id": self.config.default_notebook_id,
+                                "mode": "headless" if self.config.headless else "gui",
+                                "metrics": metrics,
+                                "system": system_info,
+                            }
 
-                return {
-                    "status": "healthy" if auth_status else "needs_auth",
-                    "message": "Server is running",
-                    "authenticated": auth_status,
-                    "notebook_id": self.config.default_notebook_id,
-                    "mode": "headless" if self.config.headless else "gui",
-                }
+                        if not client_present:
+                            return {
+                                "status": "unhealthy",
+                                "message": "Client not initialized",
+                                "authenticated": False,
+                                "notebook_id": self.config.default_notebook_id,
+                                "mode": "headless" if self.config.headless else "gui",
+                                "metrics": metrics,
+                                "system": system_info,
+                            }
 
-            except Exception as e:
-                logger.error(f"Health check failed: {e}")
-                return {
-                    "status": "error",
-                    "message": f"Health check failed: {e}",
-                    "authenticated": False,
-                }
+                        authenticated = health.authentication_status == "authenticated"
+                        browser_ok = not str(health.browser_status).startswith(
+                            "unhealthy"
+                        )
+
+                        if not authenticated:
+                            status = "needs_auth"
+                        elif browser_ok:
+                            status = "healthy"
+                        else:
+                            status = "unhealthy"
+
+                        message = {
+                            "healthy": "Server is running",
+                            "needs_auth": "Authentication required",
+                            "unhealthy": "Server requires attention",
+                        }.get(status, "Server status unknown")
+
+                        return {
+                            "status": status,
+                            "message": message,
+                            "authenticated": authenticated,
+                            "notebook_id": self.config.default_notebook_id,
+                            "mode": "headless" if self.config.headless else "gui",
+                            "metrics": metrics,
+                            "system": system_info,
+                        }
+
+                    except Exception as e:
+                        logger.error(f"Health check failed: {e}")
+                        return {
+                            "status": "error",
+                            "message": f"Health check failed: {e}",
+                            "authenticated": False,
+                        }
 
         @self.app.tool()
         async def send_chat_message(request: SendMessageRequest) -> Dict[str, Any]:
             """Send a message to NotebookLM chat interface."""
-            try:
-                await self._ensure_client()
-                await self.client.send_message(request.message)
+            async with self._request_semaphore:
+                async with request_timer():
+                    try:
+                        await self._ensure_client()
+                        if self.client is None:  # pragma: no cover - safety
+                            raise NotebookLMError("Client unavailable")
 
-                response_data = {"status": "sent", "message": request.message}
+                        await self.client.send_message(request.message)
 
-                if request.wait_for_response:
-                    response = await self.client.get_response()
-                    response_data["response"] = response
-                    response_data["status"] = "completed"
+                        response_data = {"status": "sent", "message": request.message}
 
-                logger.info(f"Message sent successfully: {request.message[:50]}...")
-                return response_data
+                        if request.wait_for_response:
+                            response = await self.client.get_response()
+                            response_data["response"] = response
+                            response_data["status"] = "completed"
 
-            except Exception as e:
-                logger.error(f"Failed to send message: {e}")
-                raise NotebookLMError(f"Failed to send message: {e}")
+                        logger.info(
+                            "Message sent successfully: %s...",
+                            request.message[:50],
+                        )
+                        return response_data
+
+                    except Exception as e:
+                        logger.error(f"Failed to send message: {e}")
+                        raise NotebookLMError(f"Failed to send message: {e}")
 
         @self.app.tool()
         async def get_chat_response(request: GetResponseRequest) -> Dict[str, Any]:
             """Get the latest response from NotebookLM with streaming support."""
-            try:
-                await self._ensure_client()
-                response = await self.client.get_response()
+            async with self._request_semaphore:
+                async with request_timer():
+                    try:
+                        await self._ensure_client()
+                        if self.client is None:  # pragma: no cover - safety
+                            raise NotebookLMError("Client unavailable")
 
-                logger.info("Response retrieved successfully")
-                return {
-                    "status": "success",
-                    "response": response,
-                    "message": "Response retrieved successfully",
-                }
+                        response = await self.client.get_response()
 
-            except Exception as e:
-                logger.error(f"Failed to get response: {e}")
-                raise NotebookLMError(f"Failed to get response: {e}")
+                        logger.info("Response retrieved successfully")
+                        return {
+                            "status": "success",
+                            "response": response,
+                            "message": "Response retrieved successfully",
+                        }
+
+                    except Exception as e:
+                        logger.error(f"Failed to get response: {e}")
+                        raise NotebookLMError(f"Failed to get response: {e}")
 
         @self.app.tool()
         async def get_quick_response() -> Dict[str, Any]:
             """Get current response without waiting for completion."""
-            try:
-                await self._ensure_client()
-                response = await self.client.get_response()
+            async with self._request_semaphore:
+                async with request_timer():
+                    try:
+                        await self._ensure_client()
+                        if self.client is None:  # pragma: no cover - safety
+                            raise NotebookLMError("Client unavailable")
 
-                return {
-                    "status": "success",
-                    "response": response,
-                    "message": "Quick response retrieved",
-                }
+                        response = await self.client.get_response()
 
-            except Exception as e:
-                logger.error(f"Failed to get quick response: {e}")
-                raise NotebookLMError(f"Failed to get quick response: {e}")
+                        return {
+                            "status": "success",
+                            "response": response,
+                            "message": "Quick response retrieved",
+                        }
+
+                    except Exception as e:
+                        logger.error(f"Failed to get quick response: {e}")
+                        raise NotebookLMError(f"Failed to get quick response: {e}")
 
         @self.app.tool()
         async def chat_with_notebook(request: ChatRequest) -> Dict[str, Any]:
             """Complete chat interaction: send message and get response."""
-            try:
-                await self._ensure_client()
+            async with self._request_semaphore:
+                async with request_timer():
+                    try:
+                        await self._ensure_client()
+                        if self.client is None:  # pragma: no cover - safety
+                            raise NotebookLMError("Client unavailable")
 
-                # Switch notebook if specified
-                if request.notebook_id:
-                    await self.client.navigate_to_notebook(request.notebook_id)
+                        if request.notebook_id:
+                            await self.client.navigate_to_notebook(request.notebook_id)
 
-                # Send message and get response
-                await self.client.send_message(request.message)
-                response = await self.client.get_response()
+                        await self.client.send_message(request.message)
+                        response = await self.client.get_response()
 
-                logger.info(f"Chat completed: {request.message[:50]}...")
-                return {
-                    "status": "success",
-                    "message": request.message,
-                    "response": response,
-                    "notebook_id": request.notebook_id
-                    or self.config.default_notebook_id,
-                }
+                        logger.info("Chat completed: %s...", request.message[:50])
+                        return {
+                            "status": "success",
+                            "message": request.message,
+                            "response": response,
+                            "notebook_id": request.notebook_id
+                            or self.config.default_notebook_id,
+                        }
 
-            except Exception as e:
-                logger.error(f"Chat interaction failed: {e}")
-                raise NotebookLMError(f"Chat interaction failed: {e}")
+                    except Exception as e:
+                        logger.error(f"Chat interaction failed: {e}")
+                        raise NotebookLMError(f"Chat interaction failed: {e}")
 
         @self.app.tool()
         async def navigate_to_notebook(request: NavigateRequest) -> Dict[str, Any]:
             """Navigate to a specific notebook."""
-            try:
-                await self._ensure_client()
-                await self.client.navigate_to_notebook(request.notebook_id)
+            async with self._request_semaphore:
+                async with request_timer():
+                    try:
+                        await self._ensure_client()
+                        if self.client is None:  # pragma: no cover - safety
+                            raise NotebookLMError("Client unavailable")
 
-                logger.info(f"Navigated to notebook: {request.notebook_id}")
-                return {
-                    "status": "success",
-                    "notebook_id": request.notebook_id,
-                    "message": f"Successfully navigated to notebook {request.notebook_id}",
-                }
+                        await self.client.navigate_to_notebook(request.notebook_id)
 
-            except Exception as e:
-                logger.error(f"Navigation failed: {e}")
-                raise NotebookLMError(f"Failed to navigate to notebook: {e}")
+                        logger.info("Navigated to notebook: %s", request.notebook_id)
+                        return {
+                            "status": "success",
+                            "notebook_id": request.notebook_id,
+                            "message": f"Successfully navigated to notebook {request.notebook_id}",
+                        }
+
+                    except Exception as e:
+                        logger.error(f"Navigation failed: {e}")
+                        raise NotebookLMError(f"Failed to navigate to notebook: {e}")
 
         @self.app.tool()
         async def get_default_notebook() -> Dict[str, Any]:
             """Get the current default notebook ID."""
-            return {
-                "status": "success",
-                "notebook_id": self.config.default_notebook_id,
-                "message": "Current default notebook ID",
-            }
+            async with self._request_semaphore:
+                async with request_timer():
+                    return {
+                        "status": "success",
+                        "notebook_id": self.config.default_notebook_id,
+                        "message": "Current default notebook ID",
+                    }
 
         @self.app.tool()
         async def set_default_notebook(request: SetNotebookRequest) -> Dict[str, Any]:
             """Set the default notebook ID."""
-            try:
-                old_notebook = self.config.default_notebook_id
-                self.config.default_notebook_id = request.notebook_id
+            async with self._request_semaphore:
+                async with request_timer():
+                    try:
+                        old_notebook = self.config.default_notebook_id
+                        self.config.default_notebook_id = request.notebook_id
 
-                logger.info(
-                    f"Default notebook changed: {old_notebook} → {request.notebook_id}"
+                        logger.info(
+                            "Default notebook changed: %s → %s",
+                            old_notebook,
+                            request.notebook_id,
+                        )
+                        return {
+                            "status": "success",
+                            "old_notebook_id": old_notebook,
+                            "new_notebook_id": request.notebook_id,
+                            "message": f"Default notebook set to {request.notebook_id}",
+                        }
+
+                    except Exception as e:
+                        logger.error(f"Failed to set default notebook: {e}")
+                        raise NotebookLMError(f"Failed to set default notebook: {e}")
+
+    def _build_http_middlewares(self) -> list[Middleware]:
+        """Construct HTTP middleware stack based on configuration"""
+
+        middlewares: list[Middleware] = []
+
+        if self.config.require_api_key and self.config.api_keys:
+            middlewares.append(
+                Middleware(
+                    APIKeyMiddleware,
+                    api_keys=set(self.config.api_keys),
+                    header=self.config.api_key_header,
+                    allow_bearer=self.config.allow_bearer_tokens,
                 )
-                return {
-                    "status": "success",
-                    "old_notebook_id": old_notebook,
-                    "new_notebook_id": request.notebook_id,
-                    "message": f"Default notebook set to {request.notebook_id}",
-                }
+            )
 
-            except Exception as e:
-                logger.error(f"Failed to set default notebook: {e}")
-                raise NotebookLMError(f"Failed to set default notebook: {e}")
+        return middlewares
 
     async def start(
         self, transport: str = "stdio", host: str = "127.0.0.1", port: int = 8000
     ):
         """Start the FastMCP v2 server with specified transport"""
         try:
+            self.config.validate()
             # Initialize client
             await self._ensure_client()
+
+            if transport in {"http", "sse"} and not self._is_local_host(host):
+                if not self.config.allow_remote_access:
+                    raise NotebookLMError(
+                        "Remote access is disabled. Set allow_remote_access=True to bind to non-local hosts."
+                    )
+                logger.warning(
+                    "Remote access enabled for %s transport on host %s", transport, host
+                )
+                if not self.config.require_api_key:
+                    logger.warning(
+                        "Remote access enabled without API key protection; consider enabling require_api_key"
+                    )
+                else:
+                    logger.info(
+                        "Remote access locked behind API key authentication using header %s",
+                        self.config.api_key_header,
+                    )
+
+            # Start monitoring helpers
+            self._start_background_tasks()
 
             # Run the FastMCP server with specified transport
             if transport == "http":
                 logger.info(f"🌐 Starting HTTP server on http://{host}:{port}/mcp/")
-                await self.app.run_async(transport="http", host=host, port=port)
+                run_kwargs: Dict[str, Any] = {
+                    "transport": "http",
+                    "host": host,
+                    "port": port,
+                }
+                middlewares = self._build_http_middlewares()
+                if middlewares:
+                    run_kwargs["middleware"] = middlewares
+                await self.app.run_async(**run_kwargs)
             elif transport == "sse":
                 logger.info(f"🌐 Starting SSE server on http://{host}:{port}/")
-                await self.app.run_async(transport="sse", host=host, port=port)
+                run_kwargs = {"transport": "sse", "host": host, "port": port}
+                middlewares = self._build_http_middlewares()
+                if middlewares:
+                    run_kwargs["middleware"] = middlewares
+                await self.app.run_async(**run_kwargs)
             else:
                 logger.info("📡 Starting STDIO server...")
                 await self.app.run_async(transport="stdio")
@@ -266,6 +484,8 @@ class NotebookLMFastMCP:
         except Exception as e:
             logger.error(f"Failed to start FastMCP server: {e}")
             raise NotebookLMError(f"Server startup failed: {e}")
+        finally:
+            await self._cleanup_background_tasks()
 
     async def stop(self):
         """Gracefully stop the server"""
@@ -273,6 +493,8 @@ class NotebookLMFastMCP:
             if self.client:
                 await self.client.close()
                 logger.info("✅ FastMCP server stopped gracefully")
+            await self._cleanup_background_tasks()
+            self.client = None
         except Exception as e:
             logger.error(f"Error during server shutdown: {e}")
 

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,52 @@
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from notebooklm_mcp.monitoring import metrics_collector
+from notebooklm_mcp.security import APIKeyMiddleware
+
+
+async def _ok_endpoint(_request):
+    return JSONResponse({"status": "ok"})
+
+
+def _build_app(**middleware_options):
+    return Starlette(
+        routes=[Route("/", _ok_endpoint)],
+        middleware=[Middleware(APIKeyMiddleware, **middleware_options)],
+    )
+
+
+def test_api_key_middleware_rejects_missing_key():
+    app = _build_app(api_keys={"secret"}, header="x-api-key", allow_bearer=True)
+    client = TestClient(app)
+
+    baseline_failures = metrics_collector.metrics.authentication_failures
+    response = client.get("/")
+
+    assert response.status_code == 401
+    assert metrics_collector.metrics.authentication_failures == baseline_failures + 1
+
+    metrics_collector.metrics.authentication_failures = baseline_failures
+
+
+def test_api_key_middleware_accepts_header():
+    app = _build_app(api_keys={"secret"}, header="x-api-key", allow_bearer=False)
+    client = TestClient(app)
+
+    response = client.get("/", headers={"x-api-key": "secret"})
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_api_key_middleware_accepts_bearer_token():
+    app = _build_app(api_keys={"secret"}, header="x-api-key", allow_bearer=True)
+    client = TestClient(app)
+
+    response = client.get("/", headers={"Authorization": "Bearer secret"})
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- add observability settings and remote-access guardrails to `ServerConfig` and CLI defaults
- integrate monitoring, concurrency limiting, and background health tasks into the FastMCP server tools
- update test suites to cover new configuration paths, monitoring hooks, and CLI options while enforcing remote access checks

## Testing
- PYTHONPATH=src python -m coverage run -m pytest
- PYTHONPATH=src python -m coverage report

------
https://chatgpt.com/codex/tasks/task_e_68cccae0d3b88321aab76c05cad67a5c