### PR TITLE
Add RPC engine (notebooklm-py) with notebook/source management; migra…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,27 @@
 FROM python:3.11-slim
 
-# Install system dependencies for Chrome and UV
+# Install system dependencies (Chrome is installed below; Patchright manages
+# its own browser driver, so no chromedriver download is needed).
 RUN apt-get update && apt-get install -y \
     wget \
     gnupg2 \
-    software-properties-common \
-    apt-transport-https \
     ca-certificates \
     curl \
-    unzip \
     && rm -rf /var/lib/apt/lists/*
 
 # Install UV Python manager
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-ENV PATH="/root/.cargo/bin:$PATH"
+ENV PATH="/root/.local/bin:/root/.cargo/bin:$PATH"
 
-# Install Google Chrome
-RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
+# Install Google Chrome (drives the app via Patchright channel="chrome").
+# Uses the modern signed-by keyring method (apt-key is deprecated/removed).
+RUN wget -q -O /usr/share/keyrings/google-chrome.gpg.key https://dl.google.com/linux/linux_signing_key.pub \
+    && gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg /usr/share/keyrings/google-chrome.gpg.key \
+    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" \
+       > /etc/apt/sources.list.d/google-chrome.list \
     && apt-get update \
     && apt-get install -y google-chrome-stable \
     && rm -rf /var/lib/apt/lists/*
-
-# Install ChromeDriver
-RUN CHROMEDRIVER_VERSION=`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE` && \
-    wget -O /tmp/chromedriver.zip http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip && \
-    unzip /tmp/chromedriver.zip chromedriver -d /usr/local/bin/ && \
-    rm /tmp/chromedriver.zip && \
-    chmod +x /usr/local/bin/chromedriver
 
 # Set up working directory
 WORKDIR /app
@@ -42,6 +36,10 @@ COPY pyproject.toml uv.lock ./
 # Install dependencies with UV
 RUN uv sync --all-groups
 
+# Ensure Patchright's browser system libraries are present (Chrome already
+# pulls most of them; this covers any gaps for headless Chromium fallback).
+RUN uv run patchright install-deps chromium || true
+
 # Copy source code
 COPY src/ ./src/
 COPY examples/ ./examples/
@@ -50,7 +48,8 @@ COPY examples/ ./examples/
 RUN uv pip install -e .
 
 # Create chrome profile directory with proper permissions
-RUN mkdir -p /app/chrome_profile && chown -R notebooklm:notebooklm /app/chrome_profile
+RUN mkdir -p /app/chrome_profile_notebooklm \
+    && chown -R notebooklm:notebooklm /app/chrome_profile_notebooklm
 
 # Switch to non-root user
 USER notebooklm
@@ -60,12 +59,14 @@ ENV PYTHONUNBUFFERED=1
 ENV UV_PYTHON=python3.11
 ENV NOTEBOOKLM_CONFIG_FILE=/app/notebooklm-config.json
 
-# Expose MCP ports
-EXPOSE 8001 8002
+# Expose the HTTP MCP port
+EXPOSE 8001
 
-# Health check with UV
+# Health check — validates the config file parses.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD uv run python -c "from notebooklm_mcp.config import ServerConfig; print('Config valid') if ServerConfig.from_file('/app/notebooklm-config.json') else exit(1)" || exit 1
+    CMD uv run python -c "from notebooklm_mcp.config import ServerConfig; ServerConfig.from_file('/app/notebooklm-config.json')" || exit 1
 
-# Default command - STDIO mode for MCP
-CMD ["uv", "run", "python", "-m", "notebooklm_mcp.cli", "--config", "/app/notebooklm-config.json", "server"]
+# Default command: HTTP transport. A detached container has no stdin, so STDIO
+# would idle with no client — HTTP is the correct transport for `docker run -d`.
+CMD ["uv", "run", "python", "-m", "notebooklm_mcp.cli", "--config", "/app/notebooklm-config.json", \
+     "server", "--transport", "http", "--host", "0.0.0.0", "--port", "8001"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   notebooklm-mcp:
     build: .
@@ -17,11 +15,10 @@ services:
       # Optional: Mount custom scripts
       - ./scripts:/app/scripts:ro
 
-    # For STDIO MCP mode (default), no ports needed
-    # For HTTP mode, uncomment appropriate port:
-    # ports:
-    #   - "8001:8001"  # HTTP transport
-    #   - "8002:8002"  # SSE transport
+    # The image's default command serves the MCP server over HTTP on 8001
+    # (a detached container has no stdin, so STDIO transport would idle).
+    ports:
+      - "8001:8001"  # HTTP transport (http://localhost:8001/mcp/)
 
     # Security settings
     security_opt:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,26 +31,24 @@ requires-python = ">=3.10"
 dependencies = [
     # Core FastMCP v2 framework
     "fastmcp>=2.0.0",
-    
-    # Web automation
-    "selenium>=4.22.0",
-    "undetected-chromedriver>=3.5.4",
-    
+    # RPC engine (default) — notebooklm-py drives NotebookLM's internal
+    # batchexecute API for fast, full notebook/source management.
+    "notebooklm-py>=0.7",
+    # Browser engine — Patchright (undetected Playwright); used to bootstrap
+    # the login session (storage_state) and as the alternative chat engine.
+    "patchright>=1.60.1",
     # Async support
     "anyio>=4.4.0",
-    "trio>=0.26.0", 
+    "trio>=0.26.0",
     "async-timeout>=4.0.3",
-    
     # Data validation and CLI
     "pydantic>=2.8.2",
     "click>=8.0.0",
     "rich>=13.0.0",
-    
     # Logging and utilities
     "loguru>=0.7.2",
     "typing-extensions>=4.0.0",
     "psutil>=5.9.0",
-    
     # TOML parsing (for Python < 3.11 compatibility)
     "tomli>=2.0.0; python_version<'3.11'",
 ]
@@ -96,15 +94,11 @@ docs = [
 
 # UV Configuration
 [tool.uv]
-# Development workflow configuration
-dev-dependencies = []  # Use dependency-groups instead
-
 # Package configuration
 package = true
 
 # Constraint dependencies for consistent resolution
 constraint-dependencies = [
-    "selenium>=4.20.0,<5.0",
     "pydantic>=2.8.0,<3.0"
 ]
 
@@ -182,8 +176,7 @@ strict_equality = true
 
 [[tool.mypy.overrides]]
 module = [
-    "selenium.*",
-    "undetected_chromedriver.*",
+    "patchright.*",
     "mcp.*",
     "loguru.*",
 ]
@@ -198,7 +191,6 @@ addopts = [
     "-p", "no:napari",
     "-p", "no:napari-plugin-engine",
     "-p", "no:npe2",
-    "-p", "no:cov",
 ]
 testpaths = ["tests"]
 python_files = ["test_*.py", "*_test.py"]
@@ -217,7 +209,6 @@ omit = [
     "*/tests/*",
     "*/test_*",
     "*/__pycache__/*",
-    "src/notebooklm_mcp/cli.py",
 ]
 
 [tool.coverage.report]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -p no:napari -p no:napari-plugin-engine -p no:npe2 -p no:cov --tb=short
+addopts = -p no:napari -p no:napari-plugin-engine -p no:npe2 --tb=short
 norecursedirs = examples
 testpaths = tests
 python_files = test_*.py *_test.py

--- a/src/notebooklm_mcp/__init__.py
+++ b/src/notebooklm_mcp/__init__.py
@@ -6,7 +6,13 @@ platform. Features enhanced type safety, decorator-based tools, and multi-transp
 support (STDIO, HTTP, SSE).
 """
 
-__version__ = "2.0.0"
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
+try:
+    __version__ = _pkg_version("notebooklm-mcp")
+except PackageNotFoundError:  # pragma: no cover - source checkout without install
+    __version__ = "0.0.0"
 __author__ = "NotebookLM MCP Team"
 __email__ = "support@notebooklm-mcp.dev"
 __description__ = (

--- a/src/notebooklm_mcp/auth_bridge.py
+++ b/src/notebooklm_mcp/auth_bridge.py
@@ -1,0 +1,66 @@
+"""Bridge the browser login session into a Playwright ``storage_state`` JSON.
+
+The RPC engine (notebooklm-py) authenticates from a ``storage_state`` file.
+The user logs in once with the persistent Chrome profile (via Patchright);
+this module exports that profile's cookies into a ``storage_state.json`` the
+RPC backend can consume. Pattern: *browser bootstraps the session, RPC drives
+the actions.*
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from loguru import logger
+
+from .config import ServerConfig
+
+APP_URL = "https://notebooklm.google.com/"
+
+
+def default_storage_state_path(config: ServerConfig) -> Path:
+    """Where the bootstrapped storage_state lives when not set explicitly."""
+    if config.auth.storage_state_path:
+        return Path(config.auth.storage_state_path).expanduser()
+    return Path(config.auth.profile_dir).expanduser() / "storage_state.json"
+
+
+async def export_storage_state(config: ServerConfig, out_path: Path) -> Path:
+    """Launch the persistent Chrome profile and dump its ``storage_state``.
+
+    Returns the path written. Raises if the browser cannot start.
+    """
+    # Imported lazily so the RPC engine has no hard import-time dependency on
+    # Patchright when a storage_state already exists.
+    from patchright.async_api import async_playwright
+
+    profile_path = Path(config.auth.profile_dir).expanduser().absolute()
+    profile_path.mkdir(parents=True, exist_ok=True)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    launch_kwargs: dict = {
+        "user_data_dir": str(profile_path),
+        "headless": config.headless,
+        "args": ["--no-sandbox", "--disable-dev-shm-usage"],
+        "no_viewport": True,
+    }
+    if config.auth.chrome_channel:
+        launch_kwargs["channel"] = config.auth.chrome_channel
+    if config.chrome_binary:
+        launch_kwargs["executable_path"] = config.chrome_binary
+
+    logger.info("Bootstrapping storage_state from Chrome profile...")
+    pw = await async_playwright().start()
+    try:
+        context = await pw.chromium.launch_persistent_context(**launch_kwargs)
+        try:
+            page = context.pages[0] if context.pages else await context.new_page()
+            await page.goto(APP_URL, wait_until="domcontentloaded")
+            await context.storage_state(path=str(out_path))
+        finally:
+            await context.close()
+    finally:
+        await pw.stop()
+
+    logger.info(f"storage_state written to {out_path}")
+    return out_path

--- a/src/notebooklm_mcp/cli.py
+++ b/src/notebooklm_mcp/cli.py
@@ -23,16 +23,22 @@ console = Console()
 
 
 def extract_notebook_id(url: str) -> str:
-    """Extract notebook ID from NotebookLM URL"""
-    # Pattern to match NotebookLM URL with notebook ID
+    """Extract a notebook ID (UUID) from a NotebookLM URL or a bare ID.
+
+    Accepts upper- or lower-case UUIDs and anchors the bare-ID form so a longer
+    hyphenated string can't yield a truncated/garbage 36-char window.
+    """
+    uuid = (
+        r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+        r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+    )
     patterns = [
-        r"https://notebooklm\.google\.com/notebook/([a-f0-9-]{36})",
-        r"notebooklm\.google\.com/notebook/([a-f0-9-]{36})",
-        r"([a-f0-9-]{36})",  # Just the ID itself
+        rf"notebooklm\.google\.com/notebook/({uuid})",
+        rf"^({uuid})$",  # Just the ID itself (anchored)
     ]
 
     for pattern in patterns:
-        match = re.search(pattern, url)
+        match = re.search(pattern, url.strip())
         if match:
             return match.group(1)
 
@@ -405,7 +411,7 @@ def quick_setup(
 ) -> None:
     """Quick setup with config file and optional profile import"""
 
-    async def run_setup():
+    async def run_setup() -> None:
         try:
             # Step 1: Create enhanced config
             console.print("📋 Step 1: Creating configuration...")

--- a/src/notebooklm_mcp/client.py
+++ b/src/notebooklm_mcp/client.py
@@ -1,476 +1,362 @@
 """
-Browser automation client for NotebookLM interactions
+Browser automation client for NotebookLM interactions.
 
-Enhanced with improved response parsing for cleaner AI responses.
+Engine: Patchright (undetected Playwright). Chosen over Selenium +
+undetected-chromedriver because it:
+
+* eliminates the chromedriver/Chrome version-matching failure
+  (``SessionNotCreatedException``) — Patchright manages its own driver and
+  drives the installed Chrome via ``channel="chrome"``;
+* patches the ``Runtime.enable`` CDP leak that Google's bot detection keys on;
+* is async-native, so the whole client is real ``async`` instead of Selenium
+  shoved through ``run_in_executor``.
+
+All DOM selectors live in :mod:`notebooklm_mcp.selectors` so UI drift is a
+one-file change.
 """
 
+from __future__ import annotations
+
 import asyncio
-import time
 from pathlib import Path
 from typing import Optional
 
 from loguru import logger
-from selenium import webdriver
-from selenium.common.exceptions import TimeoutException
-from selenium.webdriver.chrome.options import Options as ChromeOptions
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.ui import WebDriverWait
+from patchright.async_api import (
+    BrowserContext,
+    Locator,
+    Page,
+    Playwright,
+    async_playwright,
+)
+from patchright.async_api import (
+    Error as PlaywrightError,
+)
+from patchright.async_api import (
+    TimeoutError as PlaywrightTimeoutError,
+)
 
-try:
-    import undetected_chromedriver as uc
-
-    USE_UNDETECTED = True
-except ImportError:
-    USE_UNDETECTED = False
-
+from . import selectors as S
 from .config import ServerConfig
 from .exceptions import AuthenticationError, ChatError, NavigationError
 
 
 class NotebookLMClient:
-    """High-level client for NotebookLM automation"""
+    """High-level async client for NotebookLM automation."""
+
+    #: The browser/DOM engine drives chat only; it cannot do UI-independent
+    #: notebook/source management (that requires the RPC engine).
+    supports_management = False
 
     def __init__(self, config: ServerConfig):
         self.config = config
-        self.driver: Optional[webdriver.Chrome] = None
+        self._playwright: Optional[Playwright] = None
+        self.context: Optional[BrowserContext] = None
+        self.page: Optional[Page] = None
         self.current_notebook_id: Optional[str] = config.default_notebook_id
         self._is_authenticated = False
 
+    # Backwards-compatible alias: monitoring.py historically read
+    # ``client.driver``. The Playwright ``Page`` exposes ``.url`` like the old
+    # Selenium driver, so existing health checks keep working.
+    @property
+    def driver(self) -> Optional[Page]:
+        return self.page
+
+    @property
+    def is_authenticated(self) -> bool:
+        return self._is_authenticated
+
+    # ------------------------------------------------------------------ #
+    # Lifecycle
+    # ------------------------------------------------------------------ #
     async def start(self) -> None:
-        """Start browser session"""
-        await asyncio.get_event_loop().run_in_executor(None, self._start_browser)
+        """Launch a persistent, undetected Chrome session.
 
-    def _start_browser(self) -> None:
-        """Initialize browser with proper configuration"""
-        if USE_UNDETECTED:
-            logger.info("Using undetected-chromedriver for better compatibility")
+        Idempotent: calling twice is a no-op while a page is live.
+        """
+        if self.page is not None:
+            return
 
-            # Create persistent profile directory
-            if self.config.auth.use_persistent_session:
-                profile_path = Path(self.config.auth.profile_dir).absolute()
-                profile_path.mkdir(exist_ok=True)
+        profile_path = Path(self.config.auth.profile_dir).expanduser()
+        if self.config.auth.use_persistent_session:
+            profile_path = profile_path.absolute()
+            profile_path.mkdir(parents=True, exist_ok=True)
 
-            options = uc.ChromeOptions()
-            if self.config.auth.use_persistent_session:
-                options.add_argument(f"--user-data-dir={profile_path}")
-            options.add_argument("--no-first-run")
-            options.add_argument("--no-default-browser-check")
-            options.add_argument("--disable-extensions")
+        launch_args = [
+            "--no-first-run",
+            "--no-default-browser-check",
+            "--disable-blink-features=AutomationControlled",
+            "--no-sandbox",
+            "--disable-dev-shm-usage",
+        ]
 
-            if self.config.headless:
-                options.add_argument("--headless=new")
+        launch_kwargs: dict = {
+            "user_data_dir": (
+                str(profile_path) if self.config.auth.use_persistent_session else ""
+            ),
+            "headless": self.config.headless,
+            "args": launch_args,
+            "no_viewport": True,
+        }
+        # ``channel="chrome"`` uses the real installed Chrome (best stealth and
+        # the configuration proven against NotebookLM). Fall back to Patchright's
+        # bundled Chromium if Chrome isn't present.
+        if self.config.auth.chrome_channel:
+            launch_kwargs["channel"] = self.config.auth.chrome_channel
+        if self.config.chrome_binary:
+            launch_kwargs["executable_path"] = self.config.chrome_binary
 
-            self.driver = uc.Chrome(options=options, version_main=None)
-        else:
-            logger.warning(
-                "undetected-chromedriver not available, using regular Selenium"
-            )
-            # Fallback implementation with regular ChromeDriver
-            self._start_regular_chrome()
+        try:
+            self._playwright = await async_playwright().start()
+            self.context = await self._launch_context(launch_kwargs)
+        except PlaywrightError as exc:
+            # Most common cause: ``channel="chrome"`` requested but no system
+            # Chrome. Retry once with the bundled Chromium.
+            if launch_kwargs.pop("channel", None) is not None:
+                logger.warning(
+                    f"Chrome channel launch failed ({exc}); "
+                    "retrying with bundled Chromium"
+                )
+                self.context = await self._launch_context(launch_kwargs)
+            else:
+                await self._safe_shutdown()
+                raise AuthenticationError(f"Failed to launch browser: {exc}") from exc
 
-        if self.driver is None:
-            raise RuntimeError("Failed to initialize browser driver")
-        self.driver.set_page_load_timeout(self.config.timeout)
+        self.page = (
+            self.context.pages[0]
+            if self.context.pages
+            else await self.context.new_page()
+        )
+        self.page.set_default_timeout(self.config.timeout * 1000)
+        logger.info("Patchright browser session started")
 
-    def _start_regular_chrome(self) -> None:
-        """Fallback Chrome initialization"""
-        opts = ChromeOptions()
-
-        # Anti-detection options
-        opts.add_argument("--no-sandbox")
-        opts.add_argument("--disable-dev-shm-usage")
-        opts.add_argument("--disable-gpu")
-        opts.add_argument("--disable-blink-features=AutomationControlled")
-        opts.add_experimental_option("excludeSwitches", ["enable-automation"])
-        opts.add_experimental_option("useAutomationExtension", False)
-
-        # User agent
-        opts.add_argument(
-            "--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    async def _launch_context(self, launch_kwargs: dict) -> BrowserContext:
+        assert self._playwright is not None
+        return await self._playwright.chromium.launch_persistent_context(
+            **launch_kwargs
         )
 
-        if self.config.headless:
-            opts.add_argument("--headless=new")
+    async def close(self) -> None:
+        """Close the browser session. Idempotent."""
+        await self._safe_shutdown()
+        self._is_authenticated = False
 
-        self.driver = webdriver.Chrome(options=opts)
+    async def _safe_shutdown(self) -> None:
+        for closer in (self._close_context, self._stop_playwright):
+            try:
+                await closer()
+            except Exception as exc:  # pragma: no cover - best-effort cleanup
+                logger.debug(f"Shutdown step failed: {exc}")
+        self.context = None
+        self.page = None
+        self._playwright = None
 
-        # Remove automation indicators
-        self.driver.execute_script(
-            "Object.defineProperty(navigator, 'webdriver', {get: () => undefined})"
-        )
+    async def _close_context(self) -> None:
+        if self.context is not None:
+            await self.context.close()
 
+    async def _stop_playwright(self) -> None:
+        if self._playwright is not None:
+            await self._playwright.stop()
+
+    # ------------------------------------------------------------------ #
+    # Authentication
+    # ------------------------------------------------------------------ #
     async def authenticate(self) -> bool:
-        """Authenticate with NotebookLM"""
-        if not self.driver:
+        """Navigate to the target notebook and detect login state.
+
+        Auth is detected positively: we must be on the NotebookLM host, not
+        bounced to a Google sign-in URL. When a notebook is loaded we also
+        confirm the chat composer is present.
+        """
+        if self.page is None:
             raise AuthenticationError("Browser not started")
-
-        return await asyncio.get_event_loop().run_in_executor(
-            None, self._authenticate_sync
-        )
-
-    def _authenticate_sync(self) -> bool:
-        """Synchronous authentication logic"""
-        if self.driver is None:
-            raise RuntimeError("Browser driver not initialized")
 
         target_url = self.config.base_url
         if self.current_notebook_id:
             target_url = f"{self.config.base_url}/notebook/{self.current_notebook_id}"
 
         logger.info(f"Navigating to: {target_url}")
-        self.driver.get(target_url)
-
         try:
-            WebDriverWait(self.driver, 10).until(
-                EC.presence_of_element_located((By.TAG_NAME, "body"))
-            )
+            await self.page.goto(target_url, wait_until="domcontentloaded")
+        except PlaywrightTimeoutError as exc:
+            raise AuthenticationError("Page load timed out") from exc
 
-            current_url = self.driver.current_url
-            logger.debug(f"Current URL after navigation: {current_url}")
+        current_url = self.page.url
+        logger.debug(f"Current URL after navigation: {current_url}")
 
-            # Check if authenticated
-            if "signin" not in current_url and "accounts.google.com" not in current_url:
-                logger.info("✅ Already authenticated via persistent session!")
-                self._is_authenticated = True
-                return True
-            else:
-                logger.warning("❌ Authentication required - need manual login")
-                if not self.config.headless:
-                    logger.info("Browser will stay open for manual authentication")
-                self._is_authenticated = False
-                return False
+        if self._url_is_signed_out(current_url):
+            logger.warning("Authentication required - manual Google login needed")
+            self._is_authenticated = False
+            return False
 
-        except TimeoutException:
-            raise AuthenticationError("Page load timed out during authentication")
+        if S.APP_HOST not in current_url:
+            # Landed somewhere unexpected (interstitial/consent): treat as
+            # not-authenticated rather than risk a false positive.
+            logger.warning(f"Unexpected post-login URL: {current_url}")
+            self._is_authenticated = False
+            return False
 
+        # On the app host and not at a sign-in page → authenticated. If a
+        # notebook is loaded, confirm the composer renders (best-effort).
+        if self.current_notebook_id:
+            composer = await self._find_first(S.CHAT_INPUT, timeout=8000)
+            if composer is None:
+                logger.warning("On app host but chat composer not found yet")
+        logger.info("Authenticated via persistent session")
+        self._is_authenticated = True
+        return True
+
+    @staticmethod
+    def _url_is_signed_out(url: str) -> bool:
+        return any(marker in url for marker in S.SIGNED_OUT_URL_MARKERS)
+
+    # ------------------------------------------------------------------ #
+    # Messaging
+    # ------------------------------------------------------------------ #
     async def send_message(self, message: str) -> None:
-        """Send chat message to NotebookLM"""
-        if not self.driver or not self._is_authenticated:
+        """Type a message into the chat composer and submit it."""
+        if self.page is None or not self._is_authenticated:
             raise ChatError("Not authenticated or browser not ready")
 
-        await asyncio.get_event_loop().run_in_executor(
-            None, self._send_message_sync, message
-        )
+        await self._ensure_on_notebook()
 
-    def _send_message_sync(self, message: str) -> None:
-        """Synchronous message sending"""
-        if self.driver is None:
-            raise RuntimeError("Browser driver not initialized")
-
-        # Ensure we're on the right notebook
-        if self.current_notebook_id:
-            current_url = self.driver.current_url
-            expected_url = f"notebook/{self.current_notebook_id}"
-            if expected_url not in current_url:
-                self._navigate_to_notebook_sync(self.current_notebook_id)
-
-        # Find chat input with multiple fallback selectors
-        chat_selectors = [
-            "textarea[placeholder*='Ask']",
-            "textarea[data-testid*='chat']",
-            "textarea[aria-label*='message']",
-            "[contenteditable='true'][role='textbox']",
-            "input[type='text'][placeholder*='Ask']",
-            "textarea:not([disabled])",
-        ]
-
-        chat_input = None
-        for selector in chat_selectors:
-            try:
-                chat_input = WebDriverWait(self.driver, 2).until(
-                    EC.element_to_be_clickable((By.CSS_SELECTOR, selector))
-                )
-                logger.info(f"Found chat input with selector: {selector}")
-                break
-            except TimeoutException:
-                continue
-
-        if chat_input is None:
+        composer = await self._find_first(S.CHAT_INPUT, timeout=self._timeout_ms)
+        if composer is None:
             raise ChatError("Could not find chat input element")
 
-        # Send message
-        chat_input.clear()
-        chat_input.send_keys(message)
-
-        # Submit message
         try:
-            from selenium.webdriver.common.keys import Keys
+            await composer.click()
+            await composer.fill(message)
+            await composer.press("Enter")
+            logger.info("Message sent")
+        except PlaywrightError as exc:
+            raise ChatError(f"Failed to submit message: {exc}") from exc
 
-            chat_input.send_keys(Keys.RETURN)
-            logger.info("Message sent successfully")
-        except Exception as e:
-            raise ChatError(f"Failed to submit message: {e}")
+    async def _ensure_on_notebook(self) -> None:
+        if not self.current_notebook_id or self.page is None:
+            return
+        if f"notebook/{self.current_notebook_id}" not in self.page.url:
+            await self._navigate(self.current_notebook_id)
 
+    # ------------------------------------------------------------------ #
+    # Responses
+    # ------------------------------------------------------------------ #
     async def get_response(
-        self, wait_for_completion: bool = True, max_wait: int = 60
+        self, wait_for_completion: bool = True, max_wait: Optional[int] = None
     ) -> str:
-        """Get response from NotebookLM with streaming support"""
-        if not self.driver:
+        """Return the latest assistant response.
+
+        When ``wait_for_completion`` is set, wait for the streaming/thinking
+        indicator to clear and the text to stabilize before reading.
+        """
+        if self.page is None:
             raise ChatError("Browser not ready")
 
+        budget = max_wait or self.config.streaming_timeout
         if wait_for_completion:
-            return await asyncio.get_event_loop().run_in_executor(
-                None, self._wait_for_streaming_response, max_wait
-            )
-        else:
-            return await asyncio.get_event_loop().run_in_executor(
-                None, self._get_current_response
-            )
+            await self._wait_until_idle(budget)
+        text = await self._read_latest_response()
+        return text or "No response content found"
 
-    def _wait_for_streaming_response(self, max_wait: int) -> str:
-        """Wait for streaming response to complete"""
-        start_time = time.time()
-        last_response = ""
-        stable_count = 0
-        required_stable_count = self.config.response_stability_checks
+    async def _wait_until_idle(self, max_wait: int) -> None:
+        """Block until the response stops changing (stability poll)."""
+        loop = asyncio.get_event_loop()
+        deadline = loop.time() + max_wait
+        required_stable = self.config.response_stability_checks
+        last = ""
+        stable = 0
 
-        logger.info("Waiting for streaming response to complete...")
+        logger.info("Waiting for response to complete...")
+        while loop.time() < deadline:
+            current = await self._read_latest_response()
+            thinking = await self._is_thinking()
 
-        while time.time() - start_time < max_wait:
-            current_response = self._get_current_response()
-
-            if current_response == last_response:
-                stable_count += 1
-                logger.debug(
-                    f"Response stable ({stable_count}/{required_stable_count})"
-                )
-
-                # Check for streaming indicators
-                is_streaming = self._check_streaming_indicators()
-                if not is_streaming and stable_count >= required_stable_count:
-                    logger.info("✅ Response appears complete")
-                    return current_response
+            if current == last and current:
+                stable += 1
+                if not thinking and stable >= required_stable:
+                    logger.info("Response complete")
+                    return
             else:
-                stable_count = 0
-                last_response = current_response
-                logger.debug(f"Response updated: {current_response[:50]}...")
+                stable = 0
+                last = current
+            await asyncio.sleep(1)
 
-            time.sleep(1)
+        logger.warning(f"Response wait timed out ({max_wait}s)")
 
-        logger.warning(
-            f"Response wait timeout ({max_wait}s), returning current content"
-        )
-        return (
-            last_response
-            if last_response
-            else "Response timeout - no content retrieved"
-        )
-
-    def _check_streaming_indicators(self) -> bool:
-        """Check if response is still streaming"""
-        if self.driver is None:
+    async def _is_thinking(self) -> bool:
+        if self.page is None:
             return False
+        for selector in S.THINKING:
+            try:
+                if await self.page.locator(selector).first.is_visible():
+                    return True
+            except PlaywrightError:
+                continue
+        return False
 
-        try:
-            indicators = [
-                "[class*='loading']",
-                "[class*='typing']",
-                "[class*='generating']",
-                "[class*='spinner']",
-                ".dots",
-            ]
-
-            for indicator in indicators:
-                elements = self.driver.find_elements(By.CSS_SELECTOR, indicator)
-                for elem in elements:
-                    if elem.is_displayed():
-                        logger.debug(f"Found streaming indicator: {indicator}")
-                        return True
-
-            return False
-        except Exception:
-            return False
-
-    def _get_current_response(self) -> str:
-        """Get current response text, excluding user input"""
-        if self.driver is None:
+    async def _read_latest_response(self) -> str:
+        """Read the text of the newest assistant message."""
+        if self.page is None:
             return ""
-
-        response_selectors = [
-            "[data-testid*='response']",
-            "[data-testid*='message']",
-            "[role='article']",
-            "[class*='message']:last-child",
-            "[class*='response']:last-child",
-            "[class*='chat-message']:last-child",
-            ".message:last-child",
-            ".chat-bubble:last-child",
-            "[class*='ai-response']",
-            "[class*='assistant-message']",
-        ]
-
-        best_response = ""
-
-        for selector in response_selectors:
+        for selector in S.RESPONSE:
             try:
-                elements = self.driver.find_elements(By.CSS_SELECTOR, selector)
-                if elements:
-                    elem = elements[-1]
-                    text = elem.text.strip()
-
-                    if len(text) > len(best_response):
-                        best_response = text
-
-            except Exception:
+                locator = self.page.locator(selector)
+                count = await locator.count()
+                if count:
+                    text = await locator.nth(count - 1).inner_text()
+                    if text and text.strip():
+                        return text.strip()
+            except PlaywrightError:
                 continue
+        return ""
 
-        if not best_response:
-            # Fallback to any substantial text
-            try:
-                text_elements = self.driver.find_elements(
-                    By.CSS_SELECTOR, "p, div, span"
-                )
-                for elem in reversed(text_elements[-20:]):
-                    text = elem.text.strip()
-                    if len(text) > 50 and not any(
-                        skip in text.lower()
-                        for skip in [
-                            "ask about",
-                            "loading",
-                            "error",
-                            "sign in",
-                            "menu",
-                            "copy_all",
-                            "thumb_up",
-                            "thumb_down",
-                        ]
-                    ):
-                        best_response = text
-                        break
-            except Exception:
-                pass
-
-        # Clean up response by removing user input if it appears at the beginning
-        if best_response:
-            best_response = self._clean_response_text(best_response)
-
-        return best_response if best_response else "No response content found"
-
-    def _clean_response_text(self, response_text: str) -> str:
-        """Clean response text by removing user input and extracting AI response"""
-        if not response_text:
-            return response_text
-
-        # Remove UI artifacts at the end
-        ui_artifacts = [
-            "copy_all",
-            "thumb_up",
-            "thumb_down",
-            "share",
-            "more_options",
-            "like",
-            "dislike",
-        ]
-        for artifact in ui_artifacts:
-            if response_text.endswith(artifact):
-                response_text = response_text[: -len(artifact)].strip()
-
-        # Remove multiple UI artifacts that might appear together
-        lines = response_text.split("\n")
-        cleaned_lines = []
-
-        for line in lines:
-            line_clean = line.strip().lower()
-            # Skip lines that are just UI artifacts
-            if line_clean in ui_artifacts:
-                continue
-            # Skip lines with multiple UI artifacts
-            if (
-                any(artifact in line_clean for artifact in ui_artifacts)
-                and len(line_clean) < 50
-            ):
-                continue
-            cleaned_lines.append(line)
-
-        response_text = "\n".join(cleaned_lines).strip()
-
-        # Split by common delimiters that might separate user input from AI response
-        lines = response_text.split("\n")
-
-        # If response starts with the user's message, try to find where AI response begins
-        # Look for patterns that indicate the start of AI response
-        ai_response_indicators = [
-            "Mixture-of-Experts",  # Specific to MoE responses
-            "Based on",
-            "According to",
-            "Here's",
-            "Let me",
-            "I can",
-            "The answer",
-            "To answer",
-            # Common AI response starters
-        ]
-
-        # Try to find the first line that looks like an AI response
-        start_index = 0
-        for i, line in enumerate(lines):
-            line_clean = line.strip()
-            if line_clean and any(
-                indicator in line_clean for indicator in ai_response_indicators
-            ):
-                start_index = i
-                break
-            # If we find a line that's significantly longer and looks like content
-            elif len(line_clean) > 50 and not line_clean.endswith("?"):
-                start_index = i
-                break
-
-        # Join from the AI response start
-        cleaned_response = "\n".join(lines[start_index:]).strip()
-
-        # If cleaning didn't work well, try a different approach
-        if not cleaned_response or len(cleaned_response) < 50:
-            # Look for the first substantial paragraph
-            paragraphs = response_text.split("\n\n")
-            for paragraph in paragraphs:
-                if len(paragraph.strip()) > 100:  # Substantial content
-                    cleaned_response = paragraph.strip()
-                    break
-
-        # Fallback: if still no good content, return original but try to remove first line if it looks like user input
-        if not cleaned_response or len(cleaned_response) < 50:
-            if lines and len(lines) > 1:
-                first_line = lines[0].strip()
-                # If first line looks like a question or command, remove it
-                if first_line.endswith("?") or len(first_line) < 100:
-                    cleaned_response = "\n".join(lines[1:]).strip()
-                else:
-                    cleaned_response = response_text
-            else:
-                cleaned_response = response_text
-
-        return cleaned_response
-
+    # ------------------------------------------------------------------ #
+    # Navigation
+    # ------------------------------------------------------------------ #
     async def navigate_to_notebook(self, notebook_id: str) -> str:
-        """Navigate to specific notebook"""
-        if not self.driver:
+        if self.page is None:
             raise NavigationError("Browser not started")
+        return await self._navigate(notebook_id)
 
-        return await asyncio.get_event_loop().run_in_executor(
-            None, self._navigate_to_notebook_sync, notebook_id
-        )
-
-    def _navigate_to_notebook_sync(self, notebook_id: str) -> str:
-        """Synchronous notebook navigation"""
-        if self.driver is None:
-            raise RuntimeError("Browser driver not initialized")
-
+    async def _navigate(self, notebook_id: str) -> str:
+        assert self.page is not None
         url = f"{self.config.base_url}/notebook/{notebook_id}"
-        self.driver.get(url)
-
         try:
-            WebDriverWait(self.driver, self.config.timeout).until(
-                EC.presence_of_element_located((By.TAG_NAME, "body"))
-            )
-            self.current_notebook_id = notebook_id
-            return self.driver.current_url
-        except TimeoutException:
-            raise NavigationError(f"Failed to navigate to notebook {notebook_id}")
+            await self.page.goto(url, wait_until="domcontentloaded")
+        except PlaywrightTimeoutError as exc:
+            raise NavigationError(
+                f"Failed to navigate to notebook {notebook_id}"
+            ) from exc
+        self.current_notebook_id = notebook_id
+        return self.page.url
 
-    async def close(self) -> None:
-        """Close browser session"""
-        if self.driver:
-            await asyncio.get_event_loop().run_in_executor(None, self.driver.quit)
-            self.driver = None
-            self._is_authenticated = False
+    # ------------------------------------------------------------------ #
+    # Helpers
+    # ------------------------------------------------------------------ #
+    @property
+    def _timeout_ms(self) -> int:
+        return self.config.timeout * 1000
+
+    async def _find_first(
+        self, candidates: list[str], timeout: int
+    ) -> Optional[Locator]:
+        """Return the first selector's locator that becomes visible, else None.
+
+        The timeout is split across candidates so the total wait is bounded.
+        """
+        if self.page is None:
+            return None
+        per_selector = max(500, timeout // max(1, len(candidates)))
+        for selector in candidates:
+            try:
+                locator = self.page.locator(selector).first
+                await locator.wait_for(state="visible", timeout=per_selector)
+                logger.debug(f"Matched selector: {selector}")
+                return locator
+            except PlaywrightTimeoutError:
+                continue
+            except PlaywrightError:
+                continue
+        return None

--- a/src/notebooklm_mcp/client_rpc.py
+++ b/src/notebooklm_mcp/client_rpc.py
@@ -1,0 +1,206 @@
+"""RPC engine: a NotebookLM client backed by ``notebooklm-py`` (batchexecute).
+
+This is the primary engine. It speaks NotebookLM's internal RPC API instead of
+driving the DOM, which makes it fast and — crucially — gives full **notebook
+and source management** (list/create/delete/rename notebooks, add/delete
+sources) that the browser engine cannot do.
+
+It implements the same lifecycle/chat surface as
+:class:`notebooklm_mcp.client.NotebookLMClient` (``start``/``authenticate``/
+``send_message``/``get_response``/``navigate_to_notebook``/``close``) so the
+MCP server and CLI use it interchangeably, and adds management methods on top.
+
+Auth: the browser profile is used only to bootstrap a Playwright
+``storage_state`` (see :mod:`notebooklm_mcp.auth_bridge`); all actions go
+through the RPC backend.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from loguru import logger
+
+from .config import ServerConfig
+from .exceptions import ChatError, NavigationError
+
+
+def _backend_class() -> Any:
+    """Return the notebooklm-py client class (lazy import; monkeypatchable)."""
+    from notebooklm.client import NotebookLMClient as _RPCBackend
+
+    return _RPCBackend
+
+
+def _notebook_dict(nb: Any) -> Dict[str, Any]:
+    return {
+        "id": getattr(nb, "id", None),
+        "title": getattr(nb, "title", None),
+        "emoji": getattr(nb, "emoji", None),
+        "source_count": getattr(nb, "source_count", None),
+    }
+
+
+def _source_dict(src: Any) -> Dict[str, Any]:
+    return {
+        "id": getattr(src, "id", None),
+        "title": getattr(src, "title", None),
+        "type": getattr(src, "type", None) or getattr(src, "source_type", None),
+        "status": getattr(src, "status", None),
+    }
+
+
+class NotebookLMRPCClient:
+    """High-level RPC client (notebooklm-py backend) with management support."""
+
+    #: Marks this engine as capable of notebook/source management so the server
+    #: can expose those tools (the browser engine sets this False).
+    supports_management = True
+
+    def __init__(self, config: ServerConfig):
+        self.config = config
+        self.current_notebook_id: Optional[str] = config.default_notebook_id
+        self._is_authenticated = False
+        self._backend: Optional[Any] = None
+        self._cm: Optional[Any] = None
+        self._last_answer = ""
+
+    # The RPC engine has no browser page; ``driver`` stays None so the legacy
+    # health check reports "not_started" rather than crashing.
+    @property
+    def driver(self) -> None:
+        return None
+
+    @property
+    def is_authenticated(self) -> bool:
+        return self._is_authenticated
+
+    # ------------------------------------------------------------------ #
+    # Lifecycle
+    # ------------------------------------------------------------------ #
+    async def start(self) -> None:
+        """Open the RPC backend using a bootstrapped storage_state. Idempotent."""
+        if self._backend is not None:
+            return
+        storage = await self._resolve_storage_state()
+        backend_cls = _backend_class()
+        self._cm = backend_cls.from_storage(path=str(storage))
+        self._backend = await self._cm.__aenter__()
+        logger.info("RPC engine (notebooklm-py) started")
+
+    async def _resolve_storage_state(self) -> Path:
+        explicit = self.config.auth.storage_state_path
+        if explicit:
+            p = Path(explicit).expanduser()
+            if p.exists():
+                return p
+        from .auth_bridge import default_storage_state_path, export_storage_state
+
+        target = default_storage_state_path(self.config)
+        if target.exists():
+            return target
+        # Bootstrap from the persistent browser profile (one-time login reuse).
+        return await export_storage_state(self.config, target)
+
+    async def authenticate(self) -> bool:
+        """Verify the session by issuing a cheap RPC (list notebooks)."""
+        backend = self._require_backend()
+        try:
+            await backend.notebooks.list()
+            self._is_authenticated = True
+        except Exception as exc:  # noqa: BLE001 - any failure means not authed
+            logger.warning(f"RPC auth check failed: {exc}")
+            self._is_authenticated = False
+        return self._is_authenticated
+
+    async def close(self) -> None:
+        """Close the RPC backend. Idempotent."""
+        if self._cm is not None:
+            try:
+                await self._cm.__aexit__(None, None, None)
+            except Exception as exc:  # pragma: no cover - best-effort cleanup
+                logger.debug(f"RPC close failed: {exc}")
+        self._cm = None
+        self._backend = None
+        self._is_authenticated = False
+
+    # ------------------------------------------------------------------ #
+    # Chat (compatible with the browser engine surface)
+    # ------------------------------------------------------------------ #
+    async def send_message(self, message: str) -> None:
+        backend = self._require_backend()
+        notebook_id = self._require_notebook()
+        try:
+            result = await backend.chat.ask(notebook_id, message)
+        except Exception as exc:  # noqa: BLE001
+            raise ChatError(f"RPC chat failed: {exc}") from exc
+        self._last_answer = getattr(result, "answer", str(result))
+
+    async def get_response(
+        self, wait_for_completion: bool = True, max_wait: Optional[int] = None
+    ) -> str:
+        # ``chat.ask`` already returns the completed answer, so the stored
+        # answer is final; the wait args are accepted for interface parity.
+        return self._last_answer or "No response content found"
+
+    async def navigate_to_notebook(self, notebook_id: str) -> str:
+        self.current_notebook_id = notebook_id
+        return notebook_id
+
+    # ------------------------------------------------------------------ #
+    # Notebook management
+    # ------------------------------------------------------------------ #
+    async def list_notebooks(self) -> List[Dict[str, Any]]:
+        backend = self._require_backend()
+        return [_notebook_dict(nb) for nb in await backend.notebooks.list()]
+
+    async def create_notebook(self, title: str) -> Dict[str, Any]:
+        backend = self._require_backend()
+        return _notebook_dict(await backend.notebooks.create(title))
+
+    async def rename_notebook(self, notebook_id: str, new_title: str) -> Dict[str, Any]:
+        backend = self._require_backend()
+        return _notebook_dict(await backend.notebooks.rename(notebook_id, new_title))
+
+    async def delete_notebook(self, notebook_id: str) -> None:
+        backend = self._require_backend()
+        await backend.notebooks.delete(notebook_id)
+
+    async def get_notebook_summary(self, notebook_id: str) -> str:
+        backend = self._require_backend()
+        return str(await backend.notebooks.get_summary(notebook_id))
+
+    # ------------------------------------------------------------------ #
+    # Source management
+    # ------------------------------------------------------------------ #
+    async def list_sources(self, notebook_id: str) -> List[Dict[str, Any]]:
+        backend = self._require_backend()
+        return [_source_dict(s) for s in await backend.sources.list(notebook_id)]
+
+    async def add_source_url(self, notebook_id: str, url: str) -> Dict[str, Any]:
+        backend = self._require_backend()
+        return _source_dict(await backend.sources.add_url(notebook_id, url))
+
+    async def add_source_text(
+        self, notebook_id: str, title: str, text: str
+    ) -> Dict[str, Any]:
+        backend = self._require_backend()
+        return _source_dict(await backend.sources.add_text(notebook_id, title, text))
+
+    async def delete_source(self, notebook_id: str, source_id: str) -> None:
+        backend = self._require_backend()
+        await backend.sources.delete(notebook_id, source_id)
+
+    # ------------------------------------------------------------------ #
+    # Helpers
+    # ------------------------------------------------------------------ #
+    def _require_backend(self) -> Any:
+        if self._backend is None:
+            raise ChatError("RPC engine not started")
+        return self._backend
+
+    def _require_notebook(self) -> str:
+        if not self.current_notebook_id:
+            raise NavigationError("No notebook selected")
+        return self.current_notebook_id

--- a/src/notebooklm_mcp/config.py
+++ b/src/notebooklm_mcp/config.py
@@ -20,6 +20,16 @@ class AuthConfig:
     use_persistent_session: bool = True
     auto_login: bool = True
 
+    # Browser channel for Patchright. "chrome" drives the installed Google
+    # Chrome (best stealth, proven against NotebookLM). Set to None/"" to use
+    # Patchright's bundled Chromium instead.
+    chrome_channel: Optional[str] = "chrome"
+
+    # Playwright storage_state JSON used by the RPC engine (notebooklm-py).
+    # When unset, the RPC engine bootstraps it from the persistent Chrome
+    # profile above (log in once with the browser, reuse the session for RPC).
+    storage_state_path: Optional[str] = None
+
     # Quick setup options
     import_profile_from: Optional[str] = None  # Path to existing Chrome profile
     export_profile_to: Optional[str] = None  # Path to export current profile
@@ -34,6 +44,18 @@ class ServerConfig:
     headless: bool = False
     timeout: int = 60
     debug: bool = False
+
+    # Optional absolute path to the Chrome/Chromium binary. When unset,
+    # Patchright resolves the browser via the configured channel (cross-platform).
+    chrome_binary: Optional[str] = None
+
+    # Automation engine:
+    #   "rpc"       -> notebooklm-py batchexecute backend (default; fast, full
+    #                  notebook/source management). Browser used only to
+    #                  bootstrap the login session into a storage_state.
+    #   "patchright" -> the browser/DOM engine (chat only, no UI-independent
+    #                  management). Kept as an alternative.
+    engine: str = "rpc"
 
     # NotebookLM settings
     default_notebook_id: Optional[str] = None

--- a/src/notebooklm_mcp/monitoring.py
+++ b/src/notebooklm_mcp/monitoring.py
@@ -8,11 +8,16 @@ from contextlib import asynccontextmanager
 from dataclasses import asdict, dataclass
 from typing import Any, AsyncGenerator, Dict, Optional
 
-import psutil
+import psutil  # type: ignore[import-untyped]
 from loguru import logger
 
 try:
-    from prometheus_client import Counter, Gauge, Histogram, start_http_server
+    from prometheus_client import (  # type: ignore[import-not-found]
+        Counter,
+        Gauge,
+        Histogram,
+        start_http_server,
+    )
 
     PROMETHEUS_AVAILABLE = True
 except ImportError:
@@ -166,7 +171,7 @@ class HealthChecker:
                 if self.client.driver is not None:
                     try:
                         # Try to get current URL to test browser responsiveness
-                        _ = self.client.driver.current_url
+                        _ = self.client.driver.url
                         browser_status = "healthy"
                     except Exception as e:
                         browser_status = f"unhealthy: {str(e)[:50]}"

--- a/src/notebooklm_mcp/selectors.py
+++ b/src/notebooklm_mcp/selectors.py
@@ -1,0 +1,67 @@
+"""
+Single source of truth for NotebookLM DOM selectors.
+
+NotebookLM is an Angular-Material app whose markup shifts between releases, so
+every selector lives here (not scattered through the client) to make UI-drift
+maintenance a one-file change.
+
+Design rules (why these selectors and not others):
+
+* Prefer **class / structural** hooks over visible text. NotebookLM is localized
+  (the chat box placeholder is "Ask a question..." in English but
+  "Đặt câu hỏi..." in Vietnamese, etc.), so any ``placeholder*='Ask'`` selector
+  is locale-dependent and unreliable. ``textarea.query-box-input`` is stable
+  across locales — verified live against a real account (2026-06).
+* Every group is an ordered fallback list: the most specific/verified selector
+  first, looser fallbacks after. The client tries them in order.
+* The deliberately-generic ``textarea:not([disabled])`` catch-all is **excluded
+  on purpose** — on a real notebook it matches the "find new sources" textarea
+  *before* the chat box and silently sends to the wrong field.
+"""
+
+from __future__ import annotations
+
+# The chat composer (textarea you type the question into).
+# Verified live: <textarea class="... query-box-input ...">.
+CHAT_INPUT: list[str] = [
+    "textarea.query-box-input",
+    'textarea[aria-label="Input for queries"]',
+    'textarea[aria-label="Enter a query"]',
+    "textarea.query-box-textarea:not(.mat-mdc-autocomplete-trigger)",
+]
+
+# Optional explicit "send" button. Sending via Enter is primary; this is a
+# fallback for when Enter is intercepted.
+SEND_BUTTON: list[str] = [
+    'button[aria-label*="Send" i]',
+    'button[type="submit"].send-button',
+    "button.send-button",
+]
+
+# Assistant response bubbles. ``.to-user-container`` wraps messages *to* the
+# user (the model's answers); ``.message-text-content`` is the rendered text.
+# Verified live: ".to-user-container .message-text-content" isolates AI answers
+# from the user's own echoed messages.
+RESPONSE: list[str] = [
+    ".to-user-container .message-text-content",
+    "chat-message .to-user-container .message-text-content",
+    ".chat-message-container .to-user-container",
+]
+
+# "Model is generating" indicator. Present only while a response streams.
+THINKING: list[str] = [
+    "div.thinking-message",
+    ".thinking-message",
+    "[class*='thinking-message']",
+]
+
+# URL fragments that mean we were bounced to a Google sign-in flow (not authed).
+SIGNED_OUT_URL_MARKERS: tuple[str, ...] = (
+    "accounts.google.com",
+    "/signin",
+    "ServiceLogin",
+    "/ServiceLogin",
+)
+
+# Host that means we are inside the NotebookLM app (not an interstitial).
+APP_HOST: str = "notebooklm.google.com"

--- a/src/notebooklm_mcp/server.py
+++ b/src/notebooklm_mcp/server.py
@@ -53,6 +53,47 @@ class SetNotebookRequest(BaseModel):
     notebook_id: str = Field(..., description="The notebook ID to set as default")
 
 
+class CreateNotebookRequest(BaseModel):
+    """Request model for creating a notebook"""
+
+    title: str = Field(..., description="Title for the new notebook")
+
+
+class RenameNotebookRequest(BaseModel):
+    """Request model for renaming a notebook"""
+
+    notebook_id: str = Field(..., description="The notebook ID to rename")
+    new_title: str = Field(..., description="The new title")
+
+
+class NotebookIdRequest(BaseModel):
+    """Request model for operations that take only a notebook ID"""
+
+    notebook_id: str = Field(..., description="The notebook ID")
+
+
+class AddSourceUrlRequest(BaseModel):
+    """Request model for adding a URL source"""
+
+    notebook_id: str = Field(..., description="The notebook ID")
+    url: str = Field(..., description="Web URL or YouTube link to add as a source")
+
+
+class AddSourceTextRequest(BaseModel):
+    """Request model for adding a text source"""
+
+    notebook_id: str = Field(..., description="The notebook ID")
+    title: str = Field(..., description="Title for the text source")
+    text: str = Field(..., description="The raw text content")
+
+
+class DeleteSourceRequest(BaseModel):
+    """Request model for deleting a source"""
+
+    notebook_id: str = Field(..., description="The notebook ID")
+    source_id: str = Field(..., description="The source ID to delete")
+
+
 class NotebookLMFastMCP:
     """FastMCP v2 server for NotebookLM automation with enhanced error handling"""
 
@@ -70,16 +111,52 @@ class NotebookLMFastMCP:
             f"FastMCP v2 server initialized for notebook: {config.default_notebook_id}"
         )
 
-    async def _ensure_client(self) -> None:
-        """Ensure NotebookLM client is initialized and authenticated"""
+    async def _ensure_client(self) -> NotebookLMClient:
+        """Lazily initialize and authenticate the NotebookLM client.
+
+        Called on the first tool invocation (not at server startup) so the MCP
+        transport binds immediately and a browser failure degrades a single
+        tool call instead of taking down the whole server. Returns the live
+        client so callers get a non-optional reference.
+        """
         try:
             if self.client is None:
-                self.client = NotebookLMClient(self.config)
+                self.client = self._build_client()
                 await self.client.start()
-                logger.info("✅ NotebookLM client initialized and authenticated")
+                await self.client.authenticate()
+                logger.info("✅ NotebookLM client initialized")
+            return self.client
         except Exception as e:
+            # Reset so the next call can retry from a clean state.
+            self.client = None
             logger.error(f"Failed to initialize client: {e}")
             raise NotebookLMError(f"Client initialization failed: {e}")
+
+    def _build_client(self) -> Any:
+        """Construct the client for the configured engine.
+
+        ``rpc`` (default) → notebooklm-py backend with full management.
+        ``patchright`` → the browser/DOM engine (chat only). The patchright
+        branch goes through the module-level ``NotebookLMClient`` symbol so it
+        stays test-injectable.
+        """
+        engine = getattr(self.config, "engine", "rpc")
+        if engine == "patchright":
+            return NotebookLMClient(self.config)
+        from .client_rpc import NotebookLMRPCClient
+
+        return NotebookLMRPCClient(self.config)
+
+    def _require_management(self) -> Any:
+        """Return the client, ensuring the active engine supports management."""
+        if self.client is None or not getattr(
+            self.client, "supports_management", False
+        ):
+            raise NotebookLMError(
+                "Notebook/source management requires the 'rpc' engine "
+                "(set engine='rpc' in your config)."
+            )
+        return self.client
 
     def _setup_tools(self) -> None:
         """Setup FastMCP v2 tools with enhanced error handling and performance"""
@@ -117,13 +194,13 @@ class NotebookLMFastMCP:
         async def send_chat_message(request: SendMessageRequest) -> Dict[str, Any]:
             """Send a message to NotebookLM chat interface."""
             try:
-                await self._ensure_client()
-                await self.client.send_message(request.message)
+                client = await self._ensure_client()
+                await client.send_message(request.message)
 
                 response_data = {"status": "sent", "message": request.message}
 
                 if request.wait_for_response:
-                    response = await self.client.get_response()
+                    response = await client.get_response()
                     response_data["response"] = response
                     response_data["status"] = "completed"
 
@@ -138,8 +215,8 @@ class NotebookLMFastMCP:
         async def get_chat_response(request: GetResponseRequest) -> Dict[str, Any]:
             """Get the latest response from NotebookLM with streaming support."""
             try:
-                await self._ensure_client()
-                response = await self.client.get_response()
+                client = await self._ensure_client()
+                response = await client.get_response()
 
                 logger.info("Response retrieved successfully")
                 return {
@@ -156,8 +233,8 @@ class NotebookLMFastMCP:
         async def get_quick_response() -> Dict[str, Any]:
             """Get current response without waiting for completion."""
             try:
-                await self._ensure_client()
-                response = await self.client.get_response()
+                client = await self._ensure_client()
+                response = await client.get_response()
 
                 return {
                     "status": "success",
@@ -173,15 +250,15 @@ class NotebookLMFastMCP:
         async def chat_with_notebook(request: ChatRequest) -> Dict[str, Any]:
             """Complete chat interaction: send message and get response."""
             try:
-                await self._ensure_client()
+                client = await self._ensure_client()
 
                 # Switch notebook if specified
                 if request.notebook_id:
-                    await self.client.navigate_to_notebook(request.notebook_id)
+                    await client.navigate_to_notebook(request.notebook_id)
 
                 # Send message and get response
-                await self.client.send_message(request.message)
-                response = await self.client.get_response()
+                await client.send_message(request.message)
+                response = await client.get_response()
 
                 logger.info(f"Chat completed: {request.message[:50]}...")
                 return {
@@ -200,8 +277,8 @@ class NotebookLMFastMCP:
         async def navigate_to_notebook(request: NavigateRequest) -> Dict[str, Any]:
             """Navigate to a specific notebook."""
             try:
-                await self._ensure_client()
-                await self.client.navigate_to_notebook(request.notebook_id)
+                client = await self._ensure_client()
+                await client.navigate_to_notebook(request.notebook_id)
 
                 logger.info(f"Navigated to notebook: {request.notebook_id}")
                 return {
@@ -244,14 +321,143 @@ class NotebookLMFastMCP:
                 logger.error(f"Failed to set default notebook: {e}")
                 raise NotebookLMError(f"Failed to set default notebook: {e}")
 
+        # ------------------------------------------------------------------ #
+        # Notebook & source management (RPC engine only)
+        # ------------------------------------------------------------------ #
+        @self.app.tool()
+        async def list_notebooks() -> Dict[str, Any]:
+            """List all notebooks in the account."""
+            try:
+                await self._ensure_client()
+                client = self._require_management()
+                notebooks = await client.list_notebooks()
+                return {
+                    "status": "success",
+                    "count": len(notebooks),
+                    "notebooks": notebooks,
+                }
+            except Exception as e:
+                logger.error(f"Failed to list notebooks: {e}")
+                raise NotebookLMError(f"Failed to list notebooks: {e}")
+
+        @self.app.tool()
+        async def create_notebook(request: CreateNotebookRequest) -> Dict[str, Any]:
+            """Create a new notebook with the given title."""
+            try:
+                await self._ensure_client()
+                client = self._require_management()
+                notebook = await client.create_notebook(request.title)
+                return {"status": "success", "notebook": notebook}
+            except Exception as e:
+                logger.error(f"Failed to create notebook: {e}")
+                raise NotebookLMError(f"Failed to create notebook: {e}")
+
+        @self.app.tool()
+        async def rename_notebook(request: RenameNotebookRequest) -> Dict[str, Any]:
+            """Rename a notebook."""
+            try:
+                await self._ensure_client()
+                client = self._require_management()
+                notebook = await client.rename_notebook(
+                    request.notebook_id, request.new_title
+                )
+                return {"status": "success", "notebook": notebook}
+            except Exception as e:
+                logger.error(f"Failed to rename notebook: {e}")
+                raise NotebookLMError(f"Failed to rename notebook: {e}")
+
+        @self.app.tool()
+        async def delete_notebook(request: NotebookIdRequest) -> Dict[str, Any]:
+            """Delete a notebook by ID."""
+            try:
+                await self._ensure_client()
+                client = self._require_management()
+                await client.delete_notebook(request.notebook_id)
+                return {"status": "success", "notebook_id": request.notebook_id}
+            except Exception as e:
+                logger.error(f"Failed to delete notebook: {e}")
+                raise NotebookLMError(f"Failed to delete notebook: {e}")
+
+        @self.app.tool()
+        async def get_notebook_summary(request: NotebookIdRequest) -> Dict[str, Any]:
+            """Get the AI summary of a notebook."""
+            try:
+                await self._ensure_client()
+                client = self._require_management()
+                summary = await client.get_notebook_summary(request.notebook_id)
+                return {"status": "success", "summary": summary}
+            except Exception as e:
+                logger.error(f"Failed to get notebook summary: {e}")
+                raise NotebookLMError(f"Failed to get notebook summary: {e}")
+
+        @self.app.tool()
+        async def list_sources(request: NotebookIdRequest) -> Dict[str, Any]:
+            """List the sources in a notebook."""
+            try:
+                await self._ensure_client()
+                client = self._require_management()
+                sources = await client.list_sources(request.notebook_id)
+                return {
+                    "status": "success",
+                    "count": len(sources),
+                    "sources": sources,
+                }
+            except Exception as e:
+                logger.error(f"Failed to list sources: {e}")
+                raise NotebookLMError(f"Failed to list sources: {e}")
+
+        @self.app.tool()
+        async def add_source_url(request: AddSourceUrlRequest) -> Dict[str, Any]:
+            """Add a web URL (or YouTube link) as a source to a notebook."""
+            try:
+                await self._ensure_client()
+                client = self._require_management()
+                source = await client.add_source_url(request.notebook_id, request.url)
+                return {"status": "success", "source": source}
+            except Exception as e:
+                logger.error(f"Failed to add URL source: {e}")
+                raise NotebookLMError(f"Failed to add URL source: {e}")
+
+        @self.app.tool()
+        async def add_source_text(request: AddSourceTextRequest) -> Dict[str, Any]:
+            """Add raw text as a source to a notebook."""
+            try:
+                await self._ensure_client()
+                client = self._require_management()
+                source = await client.add_source_text(
+                    request.notebook_id, request.title, request.text
+                )
+                return {"status": "success", "source": source}
+            except Exception as e:
+                logger.error(f"Failed to add text source: {e}")
+                raise NotebookLMError(f"Failed to add text source: {e}")
+
+        @self.app.tool()
+        async def delete_source(request: DeleteSourceRequest) -> Dict[str, Any]:
+            """Delete a source from a notebook."""
+            try:
+                await self._ensure_client()
+                client = self._require_management()
+                await client.delete_source(request.notebook_id, request.source_id)
+                return {
+                    "status": "success",
+                    "notebook_id": request.notebook_id,
+                    "source_id": request.source_id,
+                }
+            except Exception as e:
+                logger.error(f"Failed to delete source: {e}")
+                raise NotebookLMError(f"Failed to delete source: {e}")
+
     async def start(
         self, transport: str = "stdio", host: str = "127.0.0.1", port: int = 8000
-    ):
-        """Start the FastMCP v2 server with specified transport"""
-        try:
-            # Initialize client
-            await self._ensure_client()
+    ) -> None:
+        """Start the FastMCP v2 server with specified transport.
 
+        The browser client is initialized lazily on first tool use (see
+        ``_ensure_client``), so the transport binds without requiring a working
+        browser up front.
+        """
+        try:
             # Run the FastMCP server with specified transport
             if transport == "http":
                 logger.info(f"🌐 Starting HTTP server on http://{host}:{port}/mcp/")
@@ -267,7 +473,7 @@ class NotebookLMFastMCP:
             logger.error(f"Failed to start FastMCP server: {e}")
             raise NotebookLMError(f"Server startup failed: {e}")
 
-    async def stop(self):
+    async def stop(self) -> None:
         """Gracefully stop the server"""
         try:
             if self.client:
@@ -287,7 +493,7 @@ def create_fastmcp_server(config_file: str) -> NotebookLMFastMCP:
 
 
 # Main entry point for standalone usage
-async def main():
+async def main() -> None:
     """Main entry point for running server standalone"""
     import sys
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,10 +8,340 @@ import os
 # Disable napari plugins to avoid conflicts
 import sys
 
+import patchright.async_api as pw
 import pytest
+
+from notebooklm_mcp.client import NotebookLMClient
+from notebooklm_mcp.config import ServerConfig
 
 if "napari" in sys.modules:
     del sys.modules["napari"]
+
+# Real Playwright error classes used by the faithful fakes so the production
+# ``except PlaywrightError/PlaywrightTimeoutError`` branches catch them.
+# (TimeoutError subclasses Error, mirroring patchright.)
+PWError = pw.Error
+PWTimeoutError = pw.TimeoutError
+
+
+# --------------------------------------------------------------------------- #
+# Faithful async fakes for the Patchright (async Playwright) client.
+#
+# The real client talks to ``page`` / ``context`` / ``locator`` objects whose
+# methods are all coroutines. These doubles model enough of the *real*
+# Playwright async API that the production helpers in ``client.py``
+# (``_find_first``, ``_read_latest_response``, ``_is_thinking``,
+# ``_wait_until_idle``) execute their actual DOM-walking logic against them --
+# no browser, no network, no sleeping.
+#
+# Fidelity rules that matter for the helpers under test:
+#
+# * ``page.locator(sel)`` returns DIFFERENT results per selector string. Each
+#   selector maps to a list of "element" specs; the returned ``FakeLocator``
+#   is scoped to *that* selector's element list. This lets the real selector
+#   fallback loops actually discriminate between selectors.
+# * ``locator.count()`` is the number of elements matched by the selector.
+# * ``locator.nth(i)`` indexes into that element list (like Playwright). An
+#   out-of-range index yields a locator whose ``inner_text``/``is_visible``
+#   raise a real Playwright error -- mirroring "no node for given index".
+# * ``locator.first`` is ``nth(0)``.
+# * ``locator.wait_for(state="visible", timeout=...)`` raises the real
+#   ``patchright.async_api.TimeoutError`` when no matched element is visible
+#   (i.e. the selector has no visible node within the timeout).
+# * ``locator.is_visible()`` reflects the matched element's visibility (False
+#   when the selector matched nothing, like Playwright).
+#
+# Element specs may carry *sequences* for ``text``/``visible`` so a value can
+# advance on each poll (used to model a streaming response that changes then
+# stabilizes, and a thinking indicator that flips visible -> hidden).
+# --------------------------------------------------------------------------- #
+
+
+def _advance(value, index):
+    """Resolve a possibly-sequenced spec value for poll number ``index``.
+
+    A plain scalar is returned as-is. A list/tuple is treated as a per-poll
+    timeline whose last entry sticks once exhausted (so a response "stabilizes"
+    instead of falling off the end).
+    """
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return None
+        return value[min(index, len(value) - 1)]
+    return value
+
+
+class FakeElement:
+    """One DOM node matched by a selector.
+
+    ``text`` and ``visible`` may each be a scalar or a per-poll timeline list.
+    A shared ``counter`` (a one-element list) is incremented by the owning page
+    on every ``page.locator()`` call so that ``text``/``visible`` timelines
+    advance together across the whole page, modelling sequential polls.
+    """
+
+    def __init__(self, *, text="", visible=False, raise_on=None, counter=None):
+        self._text = text
+        self._visible = visible
+        self._raise_on = raise_on or {}
+        self._counter = counter if counter is not None else [0]
+
+    def _poll(self):
+        return self._counter[0]
+
+    def _maybe_raise(self, name):
+        if name in self._raise_on:
+            raise self._raise_on[name]
+
+    @property
+    def text(self):
+        return _advance(self._text, self._poll())
+
+    @property
+    def visible(self):
+        return bool(_advance(self._visible, self._poll()))
+
+    def raises(self, name):
+        return name in self._raise_on
+
+
+class FakeLocator:
+    """Stand-in for a Playwright ``Locator`` scoped to one selector match set.
+
+    * ``elements`` is the ordered list of :class:`FakeElement` the selector
+      matched (empty list => selector matched nothing).
+    * Records ordered method calls in ``self.calls`` so tests can assert the
+      ``click -> fill -> press`` sequence used by ``send_message``.
+    * ``count()`` returns ``len(elements)``.
+    * ``nth(i)`` returns a locator scoped to that single element; out-of-range
+      yields a locator that raises a real Playwright error on read, like the
+      engine's "given index is out of range" failure.
+    * ``first`` is ``nth(0)``.
+    * ``wait_for(state="visible")`` raises the real ``TimeoutError`` when no
+      element in this set is visible.
+
+    The legacy keyword form (``text=``, ``visible=``, ``count=``, ``raise_on=``)
+    is still accepted for the ``send_message`` composer doubles and is mapped to
+    a single synthetic element so existing assertion-style tests keep working.
+    """
+
+    def __init__(
+        self,
+        *,
+        elements=None,
+        index=None,
+        text=None,
+        visible=None,
+        count=None,
+        raise_on=None,
+        _calls=None,
+    ):
+        if elements is None:
+            # Legacy single-element form (composer / direct unit doubles).
+            n = count if count is not None else 1
+            counter = [0]
+            elements = [
+                FakeElement(
+                    text=text or "",
+                    visible=bool(visible),
+                    raise_on=raise_on,
+                    counter=counter,
+                )
+                for _ in range(max(n, 1))
+            ]
+            if count == 0:
+                elements = []
+        self._elements = list(elements)
+        self._index = index
+        # ``first`` / ``nth`` clones share their parent's ``calls`` list so the
+        # full interaction (``locator -> .first -> wait_for -> click -> ...``)
+        # is recorded on one object, mirroring how the client holds a single
+        # ``Locator`` reference through the whole send sequence.
+        self.calls = _calls if _calls is not None else []
+
+    # -- helpers -------------------------------------------------------- #
+    def _scoped_element(self):
+        """The single element this (possibly ``nth``/``first``) locator points
+        at, or ``None`` for an out-of-range / empty match.
+        """
+        idx = 0 if self._index is None else self._index
+        if 0 <= idx < len(self._elements):
+            return self._elements[idx]
+        return None
+
+    @property
+    def first(self):
+        return self.nth(0)
+
+    def nth(self, index):
+        return FakeLocator(elements=self._elements, index=index, _calls=self.calls)
+
+    # -- async surface -------------------------------------------------- #
+    async def count(self):
+        return len(self._elements)
+
+    async def wait_for(self, *, state="visible", timeout=None, **_kwargs):
+        self.calls.append("wait_for")
+        element = self._scoped_element()
+        # A configured ``raise_on['wait_for']`` models a non-timeout engine
+        # failure (e.g. execution context destroyed) -> a generic Playwright
+        # ``Error`` rather than a ``TimeoutError``.
+        if element is not None:
+            element._maybe_raise("wait_for")
+        # Mirror Playwright: succeed only if an element satisfies the state.
+        if state == "visible":
+            if element is not None and element.visible:
+                return None
+            raise PWTimeoutError(
+                f"Timeout {timeout}ms exceeded waiting for visible element"
+            )
+        return None
+
+    async def inner_text(self, **_kwargs):
+        element = self._scoped_element()
+        if element is None:
+            raise PWError("Error: failed to find element matching given index")
+        element._maybe_raise("inner_text")
+        return element.text
+
+    async def is_visible(self, **_kwargs):
+        element = self._scoped_element()
+        if element is None:
+            return False
+        element._maybe_raise("is_visible")
+        return element.visible
+
+    async def click(self, **_kwargs):
+        self.calls.append("click")
+        element = self._scoped_element()
+        if element is not None:
+            element._maybe_raise("click")
+
+    async def fill(self, value, **_kwargs):
+        self.calls.append(("fill", value))
+        element = self._scoped_element()
+        if element is not None:
+            element._maybe_raise("fill")
+
+    async def press(self, key, **_kwargs):
+        self.calls.append(("press", key))
+        element = self._scoped_element()
+        if element is not None:
+            element._maybe_raise("press")
+
+
+class FakePage:
+    """Stand-in for a Playwright ``Page``.
+
+    ``locator(sel)`` returns a fresh :class:`FakeLocator` scoped to the element
+    specs registered for that exact selector string (default: an empty match).
+    Each call also advances a shared poll counter so sequenced
+    ``text``/``visible`` timelines on the elements move forward across polls.
+
+    ``goto`` updates ``self.url`` to ``goto_url`` (when set) or to the requested
+    target, or raises ``goto_error`` when configured.
+    """
+
+    def __init__(
+        self,
+        *,
+        url="https://notebooklm.google.com/notebook/abc",
+        locators=None,
+        selectors=None,
+        goto_url=None,
+        goto_error=None,
+    ):
+        self.url = url
+        # ``locators``: selector -> pre-built FakeLocator (legacy/explicit).
+        self._locators = locators or {}
+        # ``selectors``: selector -> list of FakeElement (preferred faithful
+        # form; lets one shared poll counter drive all elements together).
+        self._poll_counter = [0]
+        self._selectors = {}
+        for sel, elements in (selectors or {}).items():
+            built = []
+            for el in elements:
+                el._counter = self._poll_counter
+                built.append(el)
+            self._selectors[sel] = built
+        self._goto_url = goto_url
+        self._goto_error = goto_error
+        self.goto_calls = []
+        self.locator_calls = []
+        self.default_timeout = None
+        self.closed = False
+
+    def set_default_timeout(self, timeout):
+        self.default_timeout = timeout
+
+    async def goto(self, url, **_kwargs):
+        self.goto_calls.append(url)
+        if self._goto_error is not None:
+            raise self._goto_error
+        self.url = self._goto_url if self._goto_url is not None else url
+        return None
+
+    def locator(self, selector):
+        self.locator_calls.append(selector)
+        # Advance the poll clock once per locator() call so timelines move.
+        self._poll_counter[0] += 1
+        if selector in self._locators:
+            return self._locators[selector]
+        if selector in self._selectors:
+            return FakeLocator(elements=self._selectors[selector])
+        return FakeLocator(elements=[])
+
+    async def close(self):
+        self.closed = True
+
+
+class FakeContext:
+    """Stand-in for a Playwright ``BrowserContext``."""
+
+    def __init__(self, pages=None):
+        self.pages = list(pages) if pages else []
+        self.new_pages = []
+        self.closed = False
+
+    async def new_page(self):
+        page = FakePage()
+        self.new_pages.append(page)
+        self.pages.append(page)
+        return page
+
+    async def close(self):
+        self.closed = True
+
+
+class FakePlaywright:
+    """Stand-in for the object returned by ``async_playwright().start()``."""
+
+    def __init__(self):
+        self.stopped = False
+
+    async def stop(self):
+        self.stopped = True
+
+
+def make_async_playwright(playwright):
+    """Build a drop-in replacement for ``client.async_playwright``.
+
+    ``async_playwright()`` returns an object whose ``.start()`` coroutine yields
+    the Playwright instance, so the fake mirrors that two-step shape.
+    """
+
+    class _Factory:
+        def start(self):  # returns the awaitable below
+            return _AStart()
+
+    class _AStart:
+        def __await__(self):
+            async def _coro():
+                return playwright
+
+            return _coro().__await__()
+
+    return lambda: _Factory()
 
 
 def pytest_configure(config):
@@ -51,6 +381,31 @@ def event_loop():
 def temp_dir(tmp_path):
     """Provide temporary directory for tests"""
     return tmp_path
+
+
+@pytest.fixture
+def client_factory():
+    """Build a ``NotebookLMClient`` with an optional fake page injected.
+
+    Usage::
+
+        client = client_factory(page=FakePage(...), notebook_id="abc")
+
+    When ``page`` is provided the client is treated as "browser started"; pass
+    ``authenticated=True`` to also flip the auth flag for messaging tests.
+    """
+
+    def _make(page=None, notebook_id=None, authenticated=False, config=None):
+        cfg = config or ServerConfig(default_notebook_id=notebook_id)
+        client = NotebookLMClient(cfg)
+        if notebook_id is not None:
+            client.current_notebook_id = notebook_id
+        if page is not None:
+            client.page = page
+        client._is_authenticated = authenticated
+        return client
+
+    return _make
 
 
 @pytest.fixture

--- a/tests/test_auth_bridge.py
+++ b/tests/test_auth_bridge.py
@@ -1,0 +1,236 @@
+"""Deterministic tests for :mod:`notebooklm_mcp.auth_bridge`.
+
+``export_storage_state`` drives a real Patchright/Playwright browser in
+production. Here we monkeypatch ``patchright.async_api.async_playwright`` with a
+faithful async fake (playwright -> chromium -> launch_persistent_context ->
+context with pages/new_page/goto/storage_state/close, plus a top-level stop)
+so the production control flow runs **without launching a browser**. The fake's
+``storage_state(path=...)`` actually writes the target file, letting us assert
+that the bytes land where the production code says they do.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+import patchright.async_api as pw_module
+
+from notebooklm_mcp import auth_bridge
+from notebooklm_mcp.config import AuthConfig, ServerConfig
+
+
+# --------------------------------------------------------------------------- #
+# default_storage_state_path
+# --------------------------------------------------------------------------- #
+def test_default_storage_state_path_uses_explicit(tmp_path):
+    explicit = tmp_path / "custom" / "state.json"
+    cfg = ServerConfig(auth=AuthConfig(storage_state_path=str(explicit)))
+    # An explicit storage_state_path wins outright (expanded but otherwise
+    # verbatim), independent of profile_dir.
+    assert auth_bridge.default_storage_state_path(cfg) == explicit
+
+
+def test_default_storage_state_path_defaults_under_profile(tmp_path):
+    profile = tmp_path / "profile"
+    cfg = ServerConfig(
+        auth=AuthConfig(profile_dir=str(profile), storage_state_path=None)
+    )
+    # With no explicit path the default lives inside the profile dir.
+    assert auth_bridge.default_storage_state_path(cfg) == (
+        profile / "storage_state.json"
+    )
+
+
+def test_default_storage_state_path_expands_user(monkeypatch):
+    cfg = ServerConfig(auth=AuthConfig(storage_state_path="~/state.json"))
+    result = auth_bridge.default_storage_state_path(cfg)
+    # The leading ~ must be expanded (no literal '~' component survives).
+    assert "~" not in str(result)
+    assert str(result).endswith("state.json")
+
+
+# --------------------------------------------------------------------------- #
+# export_storage_state — faithful async Playwright fake (no real browser).
+# --------------------------------------------------------------------------- #
+class FakePage:
+    def __init__(self):
+        self.goto_calls: list[tuple] = []
+
+    async def goto(self, url, wait_until=None):
+        self.goto_calls.append((url, wait_until))
+
+
+class FakeContext:
+    """Mirrors a BrowserContext: pages list, new_page, storage_state, close."""
+
+    def __init__(self, pages):
+        self.pages = list(pages)
+        self.new_page_calls = 0
+        self.storage_state_calls: list[str] = []
+        self.closed = False
+
+    async def new_page(self):
+        self.new_page_calls += 1
+        page = FakePage()
+        self.pages.append(page)
+        return page
+
+    async def storage_state(self, path):
+        # Faithful: the real API persists the session to ``path``. We write a
+        # marker file so the test can assert the bytes landed at this exact path.
+        self.storage_state_calls.append(path)
+        with open(path, "w") as fh:
+            json.dump({"cookies": [], "origins": []}, fh)
+
+    async def close(self):
+        self.closed = True
+
+
+class FakeChromium:
+    def __init__(self, context):
+        self._context = context
+        self.launch_kwargs = None
+
+    async def launch_persistent_context(self, **kwargs):
+        self.launch_kwargs = kwargs
+        return self._context
+
+
+class FakePlaywright:
+    def __init__(self, context):
+        self.chromium = FakeChromium(context)
+        self.stopped = False
+
+    async def stop(self):
+        self.stopped = True
+
+
+def make_async_playwright(playwright):
+    """Drop-in for ``async_playwright``: ``().start()`` awaits to ``playwright``."""
+
+    class _Factory:
+        def start(self):
+            return _AStart()
+
+    class _AStart:
+        def __await__(self):
+            async def _coro():
+                return playwright
+
+            return _coro().__await__()
+
+    return lambda: _Factory()
+
+
+def install_fake_playwright(monkeypatch, *, pages):
+    context = FakeContext(pages)
+    playwright = FakePlaywright(context)
+    # The production code does `from patchright.async_api import async_playwright`
+    # at call time, so patch the symbol on the patchright module.
+    monkeypatch.setattr(
+        pw_module, "async_playwright", make_async_playwright(playwright)
+    )
+    return playwright, context
+
+
+def test_export_storage_state_writes_target_and_returns_path(tmp_path, monkeypatch):
+    out_path = tmp_path / "nested" / "dir" / "storage_state.json"
+    profile = tmp_path / "profile"
+    cfg = ServerConfig(headless=True, auth=AuthConfig(profile_dir=str(profile)))
+
+    existing_page = FakePage()
+    playwright, context = install_fake_playwright(monkeypatch, pages=[existing_page])
+
+    result = asyncio.run(auth_bridge.export_storage_state(cfg, out_path))
+
+    # Returns the path it was asked to write.
+    assert result == out_path
+    # The file was actually created at the target (fake storage_state wrote it).
+    assert out_path.exists()
+    assert json.loads(out_path.read_text()) == {"cookies": [], "origins": []}
+    assert context.storage_state_calls == [str(out_path)]
+    # Parent dir of the output was created (mkdir parents=True).
+    assert out_path.parent.is_dir()
+    # The persistent profile dir was created too.
+    assert profile.is_dir()
+    # It navigated to the app URL on the existing page (no new_page needed).
+    assert existing_page.goto_calls == [(auth_bridge.APP_URL, "domcontentloaded")]
+    assert context.new_page_calls == 0
+    # Cleanup happened: context closed, playwright stopped.
+    assert context.closed is True
+    assert playwright.stopped is True
+
+
+def test_export_storage_state_opens_new_page_when_none(tmp_path, monkeypatch):
+    out_path = tmp_path / "storage_state.json"
+    cfg = ServerConfig(auth=AuthConfig(profile_dir=str(tmp_path / "profile")))
+
+    # No pre-existing pages -> the code must open one via new_page().
+    playwright, context = install_fake_playwright(monkeypatch, pages=[])
+
+    asyncio.run(auth_bridge.export_storage_state(cfg, out_path))
+
+    assert context.new_page_calls == 1
+    # The freshly created page is the one that navigated.
+    assert context.pages and context.pages[-1].goto_calls == [
+        (auth_bridge.APP_URL, "domcontentloaded")
+    ]
+
+
+def test_export_storage_state_passes_channel_and_binary(tmp_path, monkeypatch):
+    out_path = tmp_path / "storage_state.json"
+    cfg = ServerConfig(
+        headless=True,
+        chrome_binary="/opt/google/chrome/chrome",
+        auth=AuthConfig(profile_dir=str(tmp_path / "profile"), chrome_channel="chrome"),
+    )
+    playwright, context = install_fake_playwright(monkeypatch, pages=[FakePage()])
+
+    asyncio.run(auth_bridge.export_storage_state(cfg, out_path))
+
+    kwargs = playwright.chromium.launch_kwargs
+    # Channel + executable path are forwarded only when configured.
+    assert kwargs["channel"] == "chrome"
+    assert kwargs["executable_path"] == "/opt/google/chrome/chrome"
+    assert kwargs["headless"] is True
+    assert kwargs["user_data_dir"] == str((tmp_path / "profile").absolute())
+
+
+def test_export_storage_state_omits_channel_when_unset(tmp_path, monkeypatch):
+    out_path = tmp_path / "storage_state.json"
+    cfg = ServerConfig(
+        chrome_binary=None,
+        auth=AuthConfig(profile_dir=str(tmp_path / "profile"), chrome_channel=None),
+    )
+    playwright, context = install_fake_playwright(monkeypatch, pages=[FakePage()])
+
+    asyncio.run(auth_bridge.export_storage_state(cfg, out_path))
+
+    kwargs = playwright.chromium.launch_kwargs
+    # When channel/binary are unset they must NOT appear in the launch kwargs.
+    assert "channel" not in kwargs
+    assert "executable_path" not in kwargs
+
+
+def test_export_storage_state_closes_on_error(tmp_path, monkeypatch):
+    """If navigation explodes, the context must still be closed and playwright
+    stopped (the finally blocks), and the error propagates."""
+    out_path = tmp_path / "storage_state.json"
+    cfg = ServerConfig(auth=AuthConfig(profile_dir=str(tmp_path / "profile")))
+
+    class ExplodingPage(FakePage):
+        async def goto(self, url, wait_until=None):
+            raise RuntimeError("navigation failed")
+
+    playwright, context = install_fake_playwright(monkeypatch, pages=[ExplodingPage()])
+
+    with pytest.raises(RuntimeError, match="navigation failed"):
+        asyncio.run(auth_bridge.export_storage_state(cfg, out_path))
+
+    # Even on failure: context closed, playwright stopped, no file written.
+    assert context.closed is True
+    assert playwright.stopped is True
+    assert not out_path.exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,31 +1,225 @@
+"""Tests for the CLI entry point (``notebooklm_mcp.cli``).
+
+These tests drive the REAL Click command bodies, option parsing, config
+loading, console output, and control flow. The only thing faked is the browser
+client (``NotebookLMClient``) and the FastMCP server (``NotebookLMFastMCP``),
+patched at the import boundary so no real browser or network is touched. Pure
+helpers (``extract_notebook_id``, ``create_default_config``,
+``update_config_to_headless``) are exercised directly with real temp files.
+"""
+
 import asyncio
+import json
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
 from notebooklm_mcp import cli as cli_module
 from notebooklm_mcp.config import ServerConfig
 
+# --------------------------------------------------------------------------- #
+# Helpers / fixtures
+# --------------------------------------------------------------------------- #
+
 
 def make_config_file(tmp_path: Path) -> Path:
+    """Create a real on-disk config file (the group's --config needs exists=True)."""
     path = tmp_path / "config.json"
     path.write_text("{}")
     return path
 
 
-def setup_cli(monkeypatch, tmp_path):
-    config = ServerConfig(default_notebook_id="abc")
+def setup_cli(monkeypatch, tmp_path, config=None):
+    """Patch ``load_config`` so the group yields a controlled ServerConfig.
+
+    Console output is left intact so we can assert on ``result.output``.
+    """
+    config = config or ServerConfig(default_notebook_id="abc")
     monkeypatch.setattr(cli_module, "load_config", lambda path: config)
-    monkeypatch.setattr(cli_module.console, "print", lambda *args, **kwargs: None)
     return config
 
 
 def run_asyncio(coro):
+    """A tiny ``asyncio.run`` replacement used where we want explicit loop control."""
     loop = asyncio.new_event_loop()
     try:
-        loop.run_until_complete(coro)
+        return loop.run_until_complete(coro)
     finally:
         loop.close()
+
+
+class FakeClient:
+    """Async-capable fake of ``NotebookLMClient``.
+
+    Records ordered calls so tests can assert the command actually invoked the
+    boundary (e.g. ``send_message`` with the user's message). Behaviour is
+    configurable per-instance via the class attrs set by the factory below.
+    """
+
+    instances = []
+
+    auth_result = True
+    start_error = None
+    navigate_result = "https://notebooklm.google.com/notebook/abc"
+    response_text = "a response"
+
+    def __init__(self, config):
+        self.config = config
+        self.calls = []
+        type(self).instances.append(self)
+
+    async def start(self):
+        self.calls.append("start")
+        if type(self).start_error is not None:
+            raise type(self).start_error
+
+    async def authenticate(self):
+        self.calls.append("authenticate")
+        return type(self).auth_result
+
+    async def send_message(self, message):
+        self.calls.append(("send_message", message))
+
+    async def get_response(self, *args, **kwargs):
+        self.calls.append("get_response")
+        return type(self).response_text
+
+    async def navigate_to_notebook(self, notebook_id):
+        self.calls.append(("navigate", notebook_id))
+        return type(self).navigate_result
+
+    async def close(self):
+        self.calls.append("close")
+
+
+@pytest.fixture
+def fake_client(monkeypatch):
+    """Patch the client at BOTH import sites used by the CLI.
+
+    ``cli.py`` references ``NotebookLMClient`` at module scope (init/chat/test/
+    guided_setup) and also does a function-local ``from .client import
+    NotebookLMClient`` inside ``quick_setup``. Patch both so every command path
+    gets the fake.
+    """
+    import notebooklm_mcp.client as client_module
+
+    FakeClient.instances = []
+    FakeClient.auth_result = True
+    FakeClient.start_error = None
+    FakeClient.navigate_result = "https://notebooklm.google.com/notebook/abc"
+    FakeClient.response_text = "a response"
+
+    monkeypatch.setattr(cli_module, "NotebookLMClient", FakeClient)
+    monkeypatch.setattr(client_module, "NotebookLMClient", FakeClient)
+    return FakeClient
+
+
+# --------------------------------------------------------------------------- #
+# extract_notebook_id  (pure logic)
+# --------------------------------------------------------------------------- #
+
+VALID_UUID = "123e4567-e89b-12d3-a456-426614174000"
+
+
+def test_extract_notebook_id_full_url():
+    url = f"https://notebooklm.google.com/notebook/{VALID_UUID}"
+    assert cli_module.extract_notebook_id(url) == VALID_UUID
+
+
+def test_extract_notebook_id_no_scheme():
+    url = f"notebooklm.google.com/notebook/{VALID_UUID}"
+    assert cli_module.extract_notebook_id(url) == VALID_UUID
+
+
+def test_extract_notebook_id_bare_uuid():
+    assert cli_module.extract_notebook_id(VALID_UUID) == VALID_UUID
+
+
+def test_extract_notebook_id_uppercase_uuid_accepted():
+    upper = VALID_UUID.upper()
+    assert cli_module.extract_notebook_id(upper) == upper
+
+
+def test_extract_notebook_id_with_query_string():
+    url = f"https://notebooklm.google.com/notebook/{VALID_UUID}?foo=bar&baz=1"
+    assert cli_module.extract_notebook_id(url) == VALID_UUID
+
+
+def test_extract_notebook_id_whitespace_trimmed():
+    assert cli_module.extract_notebook_id(f"  {VALID_UUID}  ") == VALID_UUID
+
+
+def test_extract_notebook_id_junk_rejected():
+    with pytest.raises(ValueError, match="Invalid NotebookLM URL or ID"):
+        cli_module.extract_notebook_id("https://example.com/not-a-notebook")
+
+
+def test_extract_notebook_id_embedded_in_longer_string_rejected():
+    # A bare UUID embedded in a longer hyphenated token must NOT yield a
+    # truncated/garbage 36-char window — the bare form is anchored (^...$).
+    embedded = f"prefix-{VALID_UUID}-suffix"
+    with pytest.raises(ValueError):
+        cli_module.extract_notebook_id(embedded)
+
+
+def test_extract_notebook_id_too_short_rejected():
+    with pytest.raises(ValueError):
+        cli_module.extract_notebook_id("123e4567-e89b-12d3-a456")
+
+
+# --------------------------------------------------------------------------- #
+# create_default_config  (pure logic, real temp file)
+# --------------------------------------------------------------------------- #
+
+
+def test_create_default_config_writes_valid_json(tmp_path):
+    path = tmp_path / "out.json"
+    cli_module.create_default_config(VALID_UUID, str(path))
+
+    assert path.exists()
+    data = json.loads(path.read_text())
+    # Spot-check the keys the rest of the system depends on.
+    assert data["default_notebook_id"] == VALID_UUID
+    assert data["headless"] is False
+    assert data["base_url"] == "https://notebooklm.google.com"
+    assert data["server_name"] == "notebooklm-mcp"
+    assert data["auth"]["profile_dir"] == "./chrome_profile_notebooklm"
+    assert data["auth"]["use_persistent_session"] is True
+    # Must round-trip into a real ServerConfig.
+    cfg = ServerConfig.from_dict(json.loads(path.read_text()))
+    assert cfg.default_notebook_id == VALID_UUID
+
+
+# --------------------------------------------------------------------------- #
+# update_config_to_headless  (pure logic, real temp file)
+# --------------------------------------------------------------------------- #
+
+
+def test_update_config_to_headless_flips_true(tmp_path):
+    path = tmp_path / "cfg.json"
+    path.write_text(json.dumps({"headless": False, "default_notebook_id": "x"}))
+
+    cli_module.update_config_to_headless(str(path))
+
+    data = json.loads(path.read_text())
+    assert data["headless"] is True
+    # Existing keys preserved.
+    assert data["default_notebook_id"] == "x"
+
+
+def test_update_config_to_headless_missing_file_is_graceful(tmp_path, capsys):
+    # No file present -> must NOT raise; emits a warning instead.
+    missing = tmp_path / "does-not-exist.json"
+    cli_module.update_config_to_headless(str(missing))
+    out = capsys.readouterr().out
+    assert "Failed to update config" in out
+    assert not missing.exists()
+
+
+# --------------------------------------------------------------------------- #
+# cli group wiring
+# --------------------------------------------------------------------------- #
 
 
 def test_cli_help(monkeypatch, tmp_path):
@@ -39,21 +233,152 @@ def test_cli_help(monkeypatch, tmp_path):
     assert "NotebookLM MCP" in result.output
 
 
-def test_server_command_invokes_start(monkeypatch, tmp_path):
-    config = setup_cli(monkeypatch, tmp_path)
+def test_cli_config_error_exits_1(monkeypatch, tmp_path):
     config_path = make_config_file(tmp_path)
 
-    calls = {}
+    def boom(_path):
+        raise RuntimeError("bad config")
 
+    monkeypatch.setattr(cli_module, "load_config", boom)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli, ["--config", str(config_path), "config-show"]
+    )
+    assert result.exit_code == 1
+    assert "Configuration error" in result.output
+
+
+def test_cli_debug_flag_sets_debug(monkeypatch, tmp_path):
+    config = ServerConfig(default_notebook_id="abc", debug=False)
+    setup_cli(monkeypatch, tmp_path, config=config)
+    config_path = make_config_file(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli, ["--config", str(config_path), "--debug", "config-show"]
+    )
+    assert result.exit_code == 0
+    assert config.debug is True
+
+
+# --------------------------------------------------------------------------- #
+# init command
+# --------------------------------------------------------------------------- #
+
+
+def test_init_creates_config_and_profile_and_reaches_guided_setup(
+    monkeypatch, fake_client
+):
+    setup_cli(monkeypatch, Path("."))
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli_module.cli, ["init", VALID_UUID])
+
+        assert result.exit_code == 0, result.output
+        # Config + profile created BEFORE the browser ran.
+        assert Path("notebooklm-config.json").exists()
+        assert Path("chrome_profile_notebooklm").is_dir()
+
+        cfg = json.loads(Path("notebooklm-config.json").read_text())
+        # guided_setup succeeded (auth=True, send_message ok) -> flipped headless.
+        assert cfg["headless"] is True
+
+    # guided_setup reached the real client and exercised its flow.
+    client = fake_client.instances[0]
+    assert ("navigate", VALID_UUID) in client.calls
+    assert any(
+        c == ("send_message", "Hello, this is a test message from setup.")
+        or (isinstance(c, tuple) and c[0] == "send_message")
+        for c in client.calls
+    )
+    assert "close" in client.calls
+    assert "✅ Setup Complete!" in result.output
+
+
+def test_init_invalid_url_exits_1(monkeypatch, fake_client):
+    setup_cli(monkeypatch, Path("."))
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli_module.cli, ["init", "not-a-valid-id"])
+    assert result.exit_code == 1
+    assert "Error:" in result.output
+    # Browser never started for an invalid URL.
+    assert fake_client.instances == []
+
+
+def test_init_browser_failure_handled_gracefully(monkeypatch, fake_client):
+    # guided_setup re-raises on client.start() failure; init wraps it and
+    # exits 1 WITHOUT crashing/tracebacking out of Click.
+    setup_cli(monkeypatch, Path("."))
+    fake_client.start_error = RuntimeError("browser exploded")
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(cli_module.cli, ["init", VALID_UUID])
+        # Config still created before the failure.
+        assert Path("notebooklm-config.json").exists()
+
+    assert result.exit_code == 1
+    assert "Setup failed" in result.output
+    # The fake's start raised -> close still called in guided_setup finally.
+    client = fake_client.instances[0]
+    assert "start" in client.calls
+    assert "close" in client.calls
+
+
+def test_init_setup_not_successful_leaves_headless_false(monkeypatch, fake_client):
+    # If auth fails AND send_message raises, guided_setup returns False, so init
+    # must NOT flip headless to true.
+    setup_cli(monkeypatch, Path("."))
+    fake_client.auth_result = False
+
+    class FailingSend(FakeClient):
+        async def send_message(self, message):
+            self.calls.append(("send_message", message))
+            raise RuntimeError("no chat")
+
+    import notebooklm_mcp.client as client_module
+
+    monkeypatch.setattr(cli_module, "NotebookLMClient", FailingSend)
+    monkeypatch.setattr(client_module, "NotebookLMClient", FailingSend)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        # headless=False path; provide stdin so the input() prompt (non-headless)
+        # does not hang.
+        result = runner.invoke(cli_module.cli, ["init", VALID_UUID], input="\n")
+        assert result.exit_code == 0, result.output
+        cfg = json.loads(Path("notebooklm-config.json").read_text())
+        assert cfg["headless"] is False
+
+
+# --------------------------------------------------------------------------- #
+# server command
+# --------------------------------------------------------------------------- #
+
+
+def _patch_fake_server(monkeypatch, calls, start_error=None):
     class DummyServer:
         def __init__(self, cfg):
             calls["config"] = cfg
 
         async def start(self, transport="stdio", host="127.0.0.1", port=8000):
             calls["params"] = (transport, host, port)
+            if start_error is not None:
+                raise start_error
 
     monkeypatch.setattr(cli_module, "NotebookLMFastMCP", DummyServer)
-    monkeypatch.setattr(cli_module.asyncio, "run", run_asyncio)
+    return DummyServer
+
+
+def test_server_builds_fastmcp_and_honors_options(monkeypatch, tmp_path):
+    config = setup_cli(monkeypatch, tmp_path)
+    config_path = make_config_file(tmp_path)
+
+    calls = {}
+    _patch_fake_server(monkeypatch, calls)
 
     runner = CliRunner()
     result = runner.invoke(
@@ -65,73 +390,515 @@ def test_server_command_invokes_start(monkeypatch, tmp_path):
             "--root-dir",
             str(tmp_path),
             "--transport",
-            "stdio",
+            "http",
+            "--notebook",
+            "nb-123",
+            "--headless",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "9001",
         ],
     )
 
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
     assert calls["config"] is config
-    assert calls["params"] == ("stdio", "127.0.0.1", 8000)
+    # --notebook / --headless flowed into the config object.
+    assert config.default_notebook_id == "nb-123"
+    assert config.headless is True
+    # --transport / --host / --port flowed into server.start.
+    assert calls["params"] == ("http", "0.0.0.0", 9001)
+    assert "FastMCP HTTP server will be available" in result.output
 
 
-def test_chat_command_sends_message(monkeypatch, tmp_path):
+def test_server_changes_working_dir(monkeypatch, tmp_path):
     setup_cli(monkeypatch, tmp_path)
     config_path = make_config_file(tmp_path)
+    calls = {}
+    _patch_fake_server(monkeypatch, calls)
 
-    created = {}
+    target = tmp_path / "workroot"
+    target.mkdir()
+    original = Path.cwd()
 
-    class DummyClient:
-        def __init__(self, cfg):
-            self.config = cfg
-            self.calls = []
-            created["client"] = self
+    runner = CliRunner()
+    try:
+        result = runner.invoke(
+            cli_module.cli,
+            ["--config", str(config_path), "server", "--root-dir", str(target)],
+        )
+        assert result.exit_code == 0, result.output
+        # os.chdir actually ran against the resolved root.
+        assert Path.cwd() == target.resolve()
+    finally:
+        import os
 
-        async def start(self):
-            self.calls.append("start")
+        os.chdir(original)
 
-        async def authenticate(self):
-            self.calls.append("authenticate")
-            return True
 
-        async def send_message(self, message):
-            self.calls.append(("send", message))
+def test_server_missing_root_dir_exits_1(monkeypatch, tmp_path):
+    setup_cli(monkeypatch, tmp_path)
+    config_path = make_config_file(tmp_path)
+    calls = {}
+    _patch_fake_server(monkeypatch, calls)
 
-        async def get_response(self):
-            self.calls.append("response")
-            return "ok"
+    missing = tmp_path / "nope"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        ["--config", str(config_path), "server", "--root-dir", str(missing)],
+    )
+    assert result.exit_code == 1
+    assert "Root directory does not exist" in result.output
 
-        async def close(self):
-            self.calls.append("close")
 
-    monkeypatch.setattr(cli_module, "NotebookLMClient", DummyClient)
-    monkeypatch.setattr(cli_module.asyncio, "run", run_asyncio)
+def test_server_auth_error_shows_help_panel(monkeypatch, tmp_path):
+    setup_cli(monkeypatch, tmp_path)
+    config_path = make_config_file(tmp_path)
+    calls = {}
+    _patch_fake_server(
+        monkeypatch, calls, start_error=RuntimeError("Authentication required: login")
+    )
+
+    original = Path.cwd()
+    runner = CliRunner()
+    try:
+        result = runner.invoke(
+            cli_module.cli,
+            ["--config", str(config_path), "server", "--root-dir", str(tmp_path)],
+        )
+    finally:
+        import os
+
+        os.chdir(original)
+
+    assert result.exit_code == 1
+    assert "Server error" in result.output
+    assert "Authentication Required" in result.output
+
+
+# --------------------------------------------------------------------------- #
+# chat command
+# --------------------------------------------------------------------------- #
+
+
+def test_chat_single_message_path(monkeypatch, tmp_path, fake_client):
+    setup_cli(monkeypatch, tmp_path)
+    config_path = make_config_file(tmp_path)
 
     runner = CliRunner()
     result = runner.invoke(
         cli_module.cli,
-        ["--config", str(config_path), "chat", "--message", "hello"],
+        ["--config", str(config_path), "chat", "--message", "hello there"],
     )
 
-    assert result.exit_code == 0
-    client = created["client"]
-    assert ("send", "hello") in client.calls
+    assert result.exit_code == 0, result.output
+    client = fake_client.instances[0]
+    assert ("send_message", "hello there") in client.calls
+    assert "get_response" in client.calls
+    assert "close" in client.calls
+    assert "a response" in result.output
+
+
+def test_chat_auth_failed_branch(monkeypatch, tmp_path, fake_client):
+    # auth fails; headless=True so no input() prompt; message still sent.
+    setup_cli(monkeypatch, tmp_path)
+    config_path = make_config_file(tmp_path)
+    fake_client.auth_result = False
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        [
+            "--config",
+            str(config_path),
+            "chat",
+            "--message",
+            "hi",
+            "--headless",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Authentication failed" in result.output
+    client = fake_client.instances[0]
+    assert ("send_message", "hi") in client.calls
+
+
+def test_chat_notebook_option_overrides_config(monkeypatch, tmp_path, fake_client):
+    config = setup_cli(monkeypatch, tmp_path)
+    config_path = make_config_file(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        [
+            "--config",
+            str(config_path),
+            "chat",
+            "--notebook",
+            "nb-override",
+            "--message",
+            "x",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert config.default_notebook_id == "nb-override"
+
+
+def test_chat_interactive_mode_loops_until_quit(monkeypatch, tmp_path, fake_client):
+    # No --message -> interactive loop. We feed two lines then "quit".
+    setup_cli(monkeypatch, tmp_path)
+    config_path = make_config_file(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        ["--config", str(config_path), "chat"],
+        input="first question\nsecond question\nquit\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    client = fake_client.instances[0]
+    sent = [c for c in client.calls if isinstance(c, tuple) and c[0] == "send_message"]
+    assert ("send_message", "first question") in sent
+    assert ("send_message", "second question") in sent
+    # "quit" must NOT be sent as a message.
+    assert ("send_message", "quit") not in sent
     assert "close" in client.calls
 
 
-def test_extract_notebook_id_parses_url():
-    notebook_id = "123e4567-e89b-12d3-a456-426614174000"
-    assert (
-        cli_module.extract_notebook_id(
-            f"https://notebooklm.google.com/notebook/{notebook_id}"
+def test_chat_session_error_wrapper_exits_1(monkeypatch, tmp_path, fake_client):
+    # client.close() raising inside run_chat's finally bubbles out of
+    # asyncio.run -> caught by the outer wrapper -> exit 1.
+    setup_cli(monkeypatch, tmp_path)
+    config_path = make_config_file(tmp_path)
+
+    class ExplodingClose(FakeClient):
+        async def close(self):
+            self.calls.append("close")
+            raise RuntimeError("close boom")
+
+    import notebooklm_mcp.client as client_module
+
+    monkeypatch.setattr(cli_module, "NotebookLMClient", ExplodingClose)
+    monkeypatch.setattr(client_module, "NotebookLMClient", ExplodingClose)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        ["--config", str(config_path), "chat", "--message", "hi", "--headless"],
+    )
+    assert result.exit_code == 1
+    assert "Chat session error" in result.output
+
+
+# --------------------------------------------------------------------------- #
+# quick_setup command
+# --------------------------------------------------------------------------- #
+
+
+def test_quick_setup_setup_only_no_browser(monkeypatch, fake_client):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli_module.cli,
+            [
+                "quick-setup",
+                "--config",
+                "qs-config.json",
+                "--notebook",
+                "nb-qs",
+                "--setup-only",
+            ],
         )
-        == notebook_id
+        assert result.exit_code == 0, result.output
+        # Config written by the real ServerConfig.save_to_file.
+        assert Path("qs-config.json").exists()
+        data = json.loads(Path("qs-config.json").read_text())
+        assert data["default_notebook_id"] == "nb-qs"
+
+    # --setup-only must NOT touch the browser.
+    assert fake_client.instances == []
+    assert "Config-Only Setup Complete" in result.output
+
+
+def test_quick_setup_with_browser_runs_client(monkeypatch, fake_client):
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli_module.cli,
+            [
+                "quick-setup",
+                "--config",
+                "qs.json",
+                "--notebook",
+                "nb-2",
+                "--headless",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert Path("qs.json").exists()
+
+    # With browser path: fake client started + authenticated + closed.
+    assert len(fake_client.instances) == 1
+    client = fake_client.instances[0]
+    assert "start" in client.calls
+    assert "authenticate" in client.calls
+    assert "close" in client.calls
+    assert "Complete Setup Success" in result.output
+
+
+def test_quick_setup_manual_login_branch(monkeypatch, fake_client):
+    # auth returns False (manual login needed). The command prints the login
+    # panel, waits for Enter, then re-checks auth. We feed an Enter line.
+    fake_client.auth_result = False
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli_module.cli,
+            ["quick-setup", "--config", "qs.json", "--notebook", "nb-3"],
+            input="\n",
+        )
+        assert result.exit_code == 0, result.output
+
+    client = fake_client.instances[0]
+    # authenticate called twice (initial + after manual login).
+    assert client.calls.count("authenticate") == 2
+    assert "Manual Login Needed" in result.output
+    assert "close" in client.calls
+
+
+def test_quick_setup_failure_exits_1(monkeypatch, fake_client):
+    # Make ServerConfig.save_to_file blow up -> outer except -> exit 1.
+    import notebooklm_mcp.cli as climod
+
+    def boom(self, path):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(climod.ServerConfig, "save_to_file", boom)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli_module.cli,
+            [
+                "quick-setup",
+                "--config",
+                "qs.json",
+                "--notebook",
+                "nb-4",
+                "--setup-only",
+            ],
+        )
+    assert result.exit_code == 1
+    assert "Setup failed" in result.output
+
+
+# --------------------------------------------------------------------------- #
+# import_profile / export_profile commands (real temp dirs, real copytree)
+# --------------------------------------------------------------------------- #
+
+
+def test_import_profile_copies_tree(monkeypatch, tmp_path):
+    setup_cli(monkeypatch, tmp_path)
+    config_path = make_config_file(tmp_path)
+
+    src = tmp_path / "src_profile"
+    src.mkdir()
+    (src / "marker.txt").write_text("hello")
+    dest = tmp_path / "dest_profile"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        [
+            "--config",
+            str(config_path),
+            "import-profile",
+            "--from-profile",
+            str(src),
+            "--to-profile",
+            str(dest),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert (dest / "marker.txt").read_text() == "hello"
+    assert "Profile Import Complete" in result.output
+
+
+def test_import_profile_overwrites_existing_dest(monkeypatch, tmp_path):
+    setup_cli(monkeypatch, tmp_path)
+    config_path = make_config_file(tmp_path)
+
+    src = tmp_path / "src_profile"
+    src.mkdir()
+    (src / "new.txt").write_text("new")
+    dest = tmp_path / "dest_profile"
+    dest.mkdir()
+    (dest / "stale.txt").write_text("stale")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        [
+            "--config",
+            str(config_path),
+            "import-profile",
+            "--from-profile",
+            str(src),
+            "--to-profile",
+            str(dest),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert (dest / "new.txt").exists()
+    assert not (dest / "stale.txt").exists()  # old tree was removed first
+
+
+def test_import_profile_missing_source_exits_1(monkeypatch, tmp_path):
+    setup_cli(monkeypatch, tmp_path)
+    config_path = make_config_file(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        [
+            "--config",
+            str(config_path),
+            "import-profile",
+            "--from-profile",
+            str(tmp_path / "missing"),
+            "--to-profile",
+            str(tmp_path / "dest"),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "Import failed" in result.output
+
+
+def test_export_profile_copies_tree(monkeypatch, tmp_path):
+    src = tmp_path / "live_profile"
+    src.mkdir()
+    (src / "cookie.txt").write_text("yum")
+    config = ServerConfig(default_notebook_id="abc")
+    config.auth.profile_dir = str(src)
+    setup_cli(monkeypatch, tmp_path, config=config)
+    config_path = make_config_file(tmp_path)
+
+    dest = tmp_path / "exported"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        ["--config", str(config_path), "export-profile", "--to", str(dest)],
+    )
+    assert result.exit_code == 0, result.output
+    assert (dest / "cookie.txt").read_text() == "yum"
+    assert "Profile Export Complete" in result.output
+
+
+def test_export_profile_missing_source_exits_1(monkeypatch, tmp_path):
+    setup_cli(monkeypatch, tmp_path)
+    config_path = make_config_file(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        [
+            "--config",
+            str(config_path),
+            "export-profile",
+            "--profile",
+            str(tmp_path / "missing_src"),
+            "--to",
+            str(tmp_path / "out"),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "Export failed" in result.output
+
+
+# --------------------------------------------------------------------------- #
+# config_show command
+# --------------------------------------------------------------------------- #
+
+
+def test_config_show_renders_table(monkeypatch, tmp_path):
+    config = ServerConfig(default_notebook_id="shown-nb")
+    setup_cli(monkeypatch, tmp_path, config=config)
+    config_path = make_config_file(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli, ["--config", str(config_path), "config-show"]
     )
 
+    assert result.exit_code == 0, result.output
+    assert "Configuration" in result.output
+    assert "shown-nb" in result.output
+    # Nested auth keys rendered as "auth.<key>".
+    assert "auth.profile_dir" in result.output
 
-def test_extract_notebook_id_invalid():
-    try:
-        cli_module.extract_notebook_id("https://example.com")
-    except ValueError as exc:
-        assert "Invalid NotebookLM URL" in str(exc)
-    else:  # pragma: no cover - defensive
-        raise AssertionError("Expected ValueError for invalid URL")
+
+# --------------------------------------------------------------------------- #
+# test command
+# --------------------------------------------------------------------------- #
+
+
+def test_test_command_happy_path(monkeypatch, tmp_path, fake_client):
+    setup_cli(monkeypatch, tmp_path)
+    config_path = make_config_file(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        ["--config", str(config_path), "test", "--notebook", "nb-test"],
+    )
+    assert result.exit_code == 0, result.output
+    client = fake_client.instances[0]
+    assert "start" in client.calls
+    assert ("navigate", "nb-test") in client.calls
+    assert "close" in client.calls
+    assert "All tests passed" in result.output
+
+
+def test_test_command_failure_exits_1(monkeypatch, tmp_path, fake_client):
+    setup_cli(monkeypatch, tmp_path)
+    config_path = make_config_file(tmp_path)
+    fake_client.start_error = RuntimeError("startup boom")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli_module.cli,
+        ["--config", str(config_path), "test", "--notebook", "nb-test"],
+    )
+    assert result.exit_code == 1
+    assert "Test" in result.output and "boom" in result.output
+    # close still called in the finally.
+    client = fake_client.instances[0]
+    assert "close" in client.calls
+
+
+# --------------------------------------------------------------------------- #
+# guided_setup (exercised directly for the already-authenticated branch)
+# --------------------------------------------------------------------------- #
+
+
+def test_guided_setup_already_authenticated_returns_true(monkeypatch, fake_client):
+    config = ServerConfig(default_notebook_id="nb-guided", headless=True)
+    result = run_asyncio(cli_module.guided_setup(config))
+    assert result is True
+    client = fake_client.instances[0]
+    assert ("navigate", "nb-guided") in client.calls
+    assert "close" in client.calls
+
+
+def test_guided_setup_no_notebook_id_raises(monkeypatch, fake_client):
+    config = ServerConfig(default_notebook_id=None, headless=True)
+    with pytest.raises(ValueError):
+        run_asyncio(cli_module.guided_setup(config))
+    # Browser was started then closed even on the error path.
+    client = fake_client.instances[0]
+    assert "start" in client.calls
+    assert "close" in client.calls

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,615 +1,1085 @@
-import asyncio
-from types import MethodType, SimpleNamespace
+"""
+Deterministic unit tests for the async Patchright-based ``NotebookLMClient``.
 
+No real browser, no network, no real sleeps. The Playwright tree is replaced by
+the *faithful* async fakes in ``conftest.py`` (``FakePage`` / ``FakeLocator`` /
+``FakeElement``). Crucially, these tests DRIVE THE REAL HELPERS
+(``_find_first``, ``_read_latest_response``, ``_is_thinking``,
+``_wait_until_idle``) through the fakes instead of monkeypatching them away, so
+the actual DOM-walking / selector-fallback / stability-poll logic is exercised.
+``asyncio.sleep`` is the only thing patched out (to avoid real waits).
+"""
+
+import patchright.async_api as pw
 import pytest
-from selenium.common.exceptions import TimeoutException
 
+from notebooklm_mcp import selectors as S
 from notebooklm_mcp.client import NotebookLMClient
 from notebooklm_mcp.config import ServerConfig
 from notebooklm_mcp.exceptions import AuthenticationError, ChatError, NavigationError
 
+from conftest import (
+    FakeContext,
+    FakeElement,
+    FakeLocator,
+    FakePage,
+    FakePlaywright,
+    make_async_playwright,
+)
 
-class ImmediateLoop:
-    def __init__(self, loop: asyncio.AbstractEventLoop):
-        self._loop = loop
-
-    def run_in_executor(self, _executor, func, *args):
-        future = self._loop.create_future()
-        try:
-            result = func(*args)
-        except Exception as exc:  # pragma: no cover - exercised in tests
-            future.set_exception(exc)
-        else:
-            future.set_result(result)
-        return future
-
-
-class DummyElement:
-    def __init__(self, text="", displayed=True):
-        self.text = text
-        self._displayed = displayed
-        self.cleared = False
-        self.sent = []
-
-    def is_displayed(self):
-        return self._displayed
-
-    def clear(self):
-        self.cleared = True
-
-    def send_keys(self, value):
-        self.sent.append(value)
-
-
-class DummyDriver:
-    def __init__(self):
-        self.current_url = "https://notebooklm.google.com/notebook/original"
-        self.calls = []
-        self.elements = {}
-
-    def set_page_load_timeout(self, timeout):
-        self.calls.append(("timeout", timeout))
-
-    def get(self, url):
-        self.current_url = url
-        self.calls.append(("get", url))
-
-    def find_elements(self, _by, selector):
-        return self.elements.get(selector, [])
-
-    def quit(self):
-        self.calls.append(("quit", None))
+# Real Playwright error classes (TimeoutError subclasses Error) for the branches
+# that catch/raise them.
+PWError = pw.Error
+PWTimeout = pw.TimeoutError
 
 
 @pytest.fixture
-def config(tmp_path):
-    profile_dir = tmp_path / "profile"
-    profile_dir.mkdir()
-    return ServerConfig(default_notebook_id="abc", auth=ServerConfig().auth)
+def no_sleep(monkeypatch):
+    """Patch only ``asyncio.sleep`` so stability polls run with zero real wait."""
+
+    async def _no_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr("notebooklm_mcp.client.asyncio.sleep", _no_sleep)
+    return _no_sleep
 
 
-def test_start_browser_uses_fallback(monkeypatch):
+# --------------------------------------------------------------------------- #
+# start()
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_start_is_noop_when_page_already_set(monkeypatch):
     client = NotebookLMClient(ServerConfig())
-    driver = DummyDriver()
+    existing = FakePage()
+    client.page = existing
 
-    monkeypatch.setattr("notebooklm_mcp.client.USE_UNDETECTED", False, raising=False)
+    # If start() tried to launch anything, this would explode.
+    def boom():
+        raise AssertionError("async_playwright must not be touched")
 
-    def fake_start(self):
-        self.driver = driver
+    monkeypatch.setattr("notebooklm_mcp.client.async_playwright", boom)
 
-    monkeypatch.setattr(
-        client,
-        "_start_regular_chrome",
-        MethodType(lambda self: fake_start(self), client),
-    )
+    await client.start()
 
-    client._start_browser()
-
-    assert client.driver is driver
-    assert ("timeout", client.config.timeout) in driver.calls
+    assert client.page is existing
 
 
 @pytest.mark.asyncio
-async def test_send_message_requires_authentication():
-    client = NotebookLMClient(ServerConfig())
-    client.driver = object()
-    client._is_authenticated = False
-
-    with pytest.raises(ChatError):
-        await client.send_message("hello")
-
-
-@pytest.mark.asyncio
-async def test_send_message_uses_executor(monkeypatch):
-    client = NotebookLMClient(ServerConfig())
-    client.driver = object()
-    client._is_authenticated = True
-    recorded = {}
-
-    def fake_send(self, message):
-        recorded["message"] = message
-
-    monkeypatch.setattr(
-        client,
-        "_send_message_sync",
-        MethodType(fake_send, client),
-    )
-
-    loop = asyncio.get_running_loop()
-    monkeypatch.setattr(
-        "notebooklm_mcp.client.asyncio.get_event_loop",
-        lambda: ImmediateLoop(loop),
-    )
-
-    await client.send_message("hi")
-    assert recorded["message"] == "hi"
-
-
-@pytest.mark.asyncio
-async def test_get_response_quick(monkeypatch):
-    client = NotebookLMClient(ServerConfig())
-    client.driver = object()
-    monkeypatch.setattr(
-        client,
-        "_get_current_response",
-        MethodType(lambda self: "response", client),
-    )
-    loop = asyncio.get_running_loop()
-    monkeypatch.setattr(
-        "notebooklm_mcp.client.asyncio.get_event_loop",
-        lambda: ImmediateLoop(loop),
-    )
-
-    result = await client.get_response(wait_for_completion=False)
-    assert result == "response"
-
-
-def test_get_current_response_prefers_longest():
-    client = NotebookLMClient(ServerConfig())
-    driver = DummyDriver()
-    driver.elements = {
-        "[data-testid*='response']": [DummyElement("short")],
-        "[class*='response']:last-child": [
-            DummyElement(
-                "This is a much longer response from NotebookLM that should be chosen"
-            )
-        ],
-    }
-    client.driver = driver
-
-    result = client._get_current_response()
-    assert "longer response" in result
-
-
-def test_check_streaming_indicators_detects_visible():
-    client = NotebookLMClient(ServerConfig())
-    driver = DummyDriver()
-    indicator = DummyElement("", displayed=True)
-    driver.elements = {
-        "[class*='loading']": [indicator],
-    }
-    client.driver = driver
-
-    assert client._check_streaming_indicators() is True
-
-
-def test_navigate_to_notebook_sync_success(monkeypatch):
-    client = NotebookLMClient(ServerConfig())
-    driver = DummyDriver()
-    client.driver = driver
-
-    class DummyWait:
-        def __init__(self, *_args, **_kwargs):
-            pass
-
-        def until(self, condition):
-            return condition
-
-    monkeypatch.setattr("notebooklm_mcp.client.WebDriverWait", DummyWait)
-
-    url = client._navigate_to_notebook_sync("updated")
-    assert "updated" in url
-    assert client.current_notebook_id == "updated"
-
-
-def test_navigate_to_notebook_sync_timeout(monkeypatch):
-    client = NotebookLMClient(ServerConfig())
-    driver = DummyDriver()
-    client.driver = driver
-
-    class DummyWait:
-        def __init__(self, *_args, **_kwargs):
-            pass
-
-        def until(self, _condition):
-            raise TimeoutException()
-
-    monkeypatch.setattr("notebooklm_mcp.client.WebDriverWait", DummyWait)
-
-    with pytest.raises(NavigationError):
-        client._navigate_to_notebook_sync("bad")
-
-
-@pytest.mark.asyncio
-async def test_close_runs_quit(monkeypatch):
-    client = NotebookLMClient(ServerConfig())
-    driver = DummyDriver()
-    client.driver = driver
-    client._is_authenticated = True
-
-    loop = asyncio.get_running_loop()
-    monkeypatch.setattr(
-        "notebooklm_mcp.client.asyncio.get_event_loop",
-        lambda: ImmediateLoop(loop),
-    )
-
-    await client.close()
-
-    assert client.driver is None
-    assert client._is_authenticated is False
-    assert ("quit", None) in driver.calls
-
-
-def test_clean_response_text_removes_artifacts():
-    client = NotebookLMClient(ServerConfig())
-    messy = (
-        "What is NotebookLM?\n"
-        "NotebookLM is a tool designed to help organize research notes and generate answers from sources.\n"
-        "thumb_up\nthumb_down"
-    )
-
-    cleaned = client._clean_response_text(messy)
-
-    assert "thumb_up" not in cleaned
-    assert "NotebookLM is a tool" in cleaned
-
-
-def test_send_message_sync_success(monkeypatch):
-    config = ServerConfig(default_notebook_id="abc")
-    client = NotebookLMClient(config)
-    driver = DummyDriver()
-    driver.current_url = "https://notebooklm.google.com/notebook/abc"
-    client.driver = driver
-    element = DummyElement()
-
-    class DummyWait:
-        def __init__(self, *_args, **_kwargs):
-            pass
-
-        def until(self, _condition):
-            return element
-
-    monkeypatch.setattr("notebooklm_mcp.client.WebDriverWait", DummyWait)
-    monkeypatch.setattr(
-        "selenium.webdriver.common.keys.Keys.RETURN",
-        "RETURN",
-        raising=False,
-    )
-
-    client._send_message_sync("hello")
-
-    assert element.cleared is True
-    assert "hello" in element.sent[0]
-    assert "RETURN" in element.sent[-1]
-
-
-def test_send_message_sync_no_element(monkeypatch):
-    client = NotebookLMClient(ServerConfig(default_notebook_id="abc"))
-    client.driver = DummyDriver()
-    client.driver.current_url = "https://notebooklm.google.com/notebook/abc"
-
-    class DummyWait:
-        def __init__(self, *_args, **_kwargs):
-            pass
-
-        def until(self, _condition):
-            raise TimeoutException()
-
-    monkeypatch.setattr("notebooklm_mcp.client.WebDriverWait", DummyWait)
-
-    with pytest.raises(ChatError):
-        client._send_message_sync("hello")
-
-
-def test_wait_for_streaming_response(monkeypatch):
-    config = ServerConfig(response_stability_checks=1)
+async def test_start_happy_path(monkeypatch, tmp_path):
+    config = ServerConfig(timeout=30)
+    config.auth.profile_dir = str(tmp_path / "profile")
+    config.auth.use_persistent_session = True
     client = NotebookLMClient(config)
 
+    page = FakePage()
+    context = FakeContext(pages=[page])
+    playwright = FakePlaywright()
+
     monkeypatch.setattr(
-        client,
-        "_get_current_response",
-        MethodType(lambda self: "Answer", client),
-    )
-    monkeypatch.setattr(
-        client,
-        "_check_streaming_indicators",
-        MethodType(lambda self: False, client),
+        "notebooklm_mcp.client.async_playwright",
+        make_async_playwright(playwright),
     )
 
-    times = iter([0, 0.1, 0.2])
-    monkeypatch.setattr("notebooklm_mcp.client.time.time", lambda: next(times, 1.0))
-    monkeypatch.setattr("notebooklm_mcp.client.time.sleep", lambda _s: None)
+    captured = {}
 
-    assert client._wait_for_streaming_response(max_wait=1) == "Answer"
+    async def fake_launch(self, launch_kwargs):
+        captured["kwargs"] = launch_kwargs
+        return context
+
+    monkeypatch.setattr(NotebookLMClient, "_launch_context", fake_launch)
+
+    await client.start()
+
+    assert client.page is page
+    assert client._playwright is playwright
+    assert client.context is context
+    assert page.default_timeout == config.timeout * 1000
+    # Persistent session => the profile dir was created.
+    assert (tmp_path / "profile").is_dir()
+    # Channel was passed through from auth config (default "chrome").
+    assert captured["kwargs"]["channel"] == "chrome"
 
 
 @pytest.mark.asyncio
-async def test_get_response_streaming(monkeypatch):
-    client = NotebookLMClient(ServerConfig())
-    client.driver = object()
+async def test_start_non_persistent_session_skips_profile_dir(monkeypatch, tmp_path):
+    """With ``use_persistent_session=False`` the profile dir is NOT created and
+    ``user_data_dir`` is empty (covers the client.py:78->82 branch skip).
+    """
+    config = ServerConfig()
+    profile = tmp_path / "should-not-exist"
+    config.auth.profile_dir = str(profile)
+    config.auth.use_persistent_session = False
+    client = NotebookLMClient(config)
 
+    context = FakeContext(pages=[FakePage()])
+    playwright = FakePlaywright()
     monkeypatch.setattr(
-        client,
-        "_wait_for_streaming_response",
-        MethodType(lambda self, _max_wait: "complete", client),
-    )
-    loop = asyncio.get_running_loop()
-    monkeypatch.setattr(
-        "notebooklm_mcp.client.asyncio.get_event_loop",
-        lambda: ImmediateLoop(loop),
+        "notebooklm_mcp.client.async_playwright",
+        make_async_playwright(playwright),
     )
 
-    result = await client.get_response(wait_for_completion=True)
-    assert result == "complete"
+    captured = {}
+
+    async def fake_launch(self, launch_kwargs):
+        captured["kwargs"] = launch_kwargs
+        return context
+
+    monkeypatch.setattr(NotebookLMClient, "_launch_context", fake_launch)
+
+    await client.start()
+
+    assert not profile.exists()
+    assert captured["kwargs"]["user_data_dir"] == ""
 
 
 @pytest.mark.asyncio
-async def test_start_invokes_browser(monkeypatch):
-    client = NotebookLMClient(ServerConfig())
-    called = {}
+async def test_start_passes_chrome_binary_as_executable_path(monkeypatch, tmp_path):
+    """When ``chrome_binary`` is set it is forwarded as ``executable_path``
+    (covers client.py:103-104).
+    """
+    config = ServerConfig(timeout=15, chrome_binary="/opt/chrome/chrome")
+    config.auth.profile_dir = str(tmp_path / "profile")
+    config.auth.use_persistent_session = True
+    client = NotebookLMClient(config)
 
-    def fake_start(self):
-        called["start"] = True
-
+    context = FakeContext(pages=[FakePage()])
+    playwright = FakePlaywright()
     monkeypatch.setattr(
-        client,
-        "_start_browser",
-        MethodType(lambda self: fake_start(self), client),
+        "notebooklm_mcp.client.async_playwright",
+        make_async_playwright(playwright),
     )
-    loop = asyncio.get_running_loop()
+
+    captured = {}
+
+    async def fake_launch(self, launch_kwargs):
+        captured["kwargs"] = launch_kwargs
+        return context
+
+    monkeypatch.setattr(NotebookLMClient, "_launch_context", fake_launch)
+
+    await client.start()
+
+    assert captured["kwargs"]["executable_path"] == "/opt/chrome/chrome"
+
+
+@pytest.mark.asyncio
+async def test_start_creates_page_when_context_empty(monkeypatch):
+    client = NotebookLMClient(ServerConfig())
+    context = FakeContext(pages=[])  # no pages -> new_page() path
+    playwright = FakePlaywright()
+
     monkeypatch.setattr(
-        "notebooklm_mcp.client.asyncio.get_event_loop",
-        lambda: ImmediateLoop(loop),
+        "notebooklm_mcp.client.async_playwright",
+        make_async_playwright(playwright),
+    )
+
+    async def fake_launch(self, launch_kwargs):
+        return context
+
+    monkeypatch.setattr(NotebookLMClient, "_launch_context", fake_launch)
+
+    await client.start()
+
+    assert client.page is context.new_pages[0]
+
+
+@pytest.mark.asyncio
+async def test_start_channel_fallback(monkeypatch):
+    """First launch (with channel) raises; retry without channel succeeds."""
+    config = ServerConfig()
+    config.auth.chrome_channel = "chrome"
+    client = NotebookLMClient(config)
+
+    page = FakePage()
+    context = FakeContext(pages=[page])
+    playwright = FakePlaywright()
+
+    monkeypatch.setattr(
+        "notebooklm_mcp.client.async_playwright",
+        make_async_playwright(playwright),
+    )
+
+    attempts = []
+
+    async def fake_launch(self, launch_kwargs):
+        attempts.append(dict(launch_kwargs))
+        if "channel" in launch_kwargs:
+            raise PWError("no system chrome")
+        return context
+
+    monkeypatch.setattr(NotebookLMClient, "_launch_context", fake_launch)
+
+    await client.start()
+
+    assert len(attempts) == 2
+    assert attempts[0]["channel"] == "chrome"
+    assert "channel" not in attempts[1]
+    assert client.page is page
+
+
+@pytest.mark.asyncio
+async def test_start_raises_auth_error_when_no_channel_to_drop(monkeypatch):
+    """Launch fails and there is no channel to retry without -> AuthenticationError.
+
+    Exercises the real error/fallback branch (client.py:104): no ``channel``
+    present means there is nothing to pop, so ``_safe_shutdown`` runs and an
+    ``AuthenticationError`` is raised.
+    """
+    config = ServerConfig()
+    config.auth.chrome_channel = None  # nothing to pop
+    client = NotebookLMClient(config)
+    playwright = FakePlaywright()
+
+    monkeypatch.setattr(
+        "notebooklm_mcp.client.async_playwright",
+        make_async_playwright(playwright),
+    )
+
+    async def fake_launch(self, launch_kwargs):
+        raise PWError("kaboom")
+
+    shutdown_called = {}
+
+    async def fake_shutdown(self):
+        shutdown_called["yes"] = True
+
+    monkeypatch.setattr(NotebookLMClient, "_launch_context", fake_launch)
+    monkeypatch.setattr(NotebookLMClient, "_safe_shutdown", fake_shutdown)
+
+    with pytest.raises(AuthenticationError, match="Failed to launch browser"):
+        await client.start()
+
+    assert shutdown_called.get("yes") is True
+
+
+@pytest.mark.asyncio
+async def test_launch_context_invokes_chromium_persistent_context(monkeypatch):
+    """The real ``_launch_context`` (client.py:131-132) forwards kwargs to
+    ``chromium.launch_persistent_context`` and returns its result.
+    """
+    config = ServerConfig()
+    client = NotebookLMClient(config)
+
+    context = FakeContext(pages=[FakePage()])
+    received = {}
+
+    class FakeChromium:
+        async def launch_persistent_context(self, **kwargs):
+            received.update(kwargs)
+            return context
+
+    class FakePlaywrightWithChromium(FakePlaywright):
+        def __init__(self):
+            super().__init__()
+            self.chromium = FakeChromium()
+
+    client._playwright = FakePlaywrightWithChromium()
+
+    launch_kwargs = {"user_data_dir": "/tmp/profile", "headless": True}
+    result = await client._launch_context(launch_kwargs)
+
+    assert result is context
+    assert received == launch_kwargs
+
+
+@pytest.mark.asyncio
+async def test_start_drives_real_launch_context_and_fallback(monkeypatch, tmp_path):
+    """End-to-end through the REAL ``_launch_context``: first call (with the
+    ``channel`` kwarg) raises a Playwright ``Error``; ``start`` retries via the
+    real ``_launch_context`` again, which succeeds with the bundled Chromium.
+    """
+    config = ServerConfig(timeout=10)
+    config.auth.chrome_channel = "chrome"
+    config.auth.profile_dir = str(tmp_path / "profile")
+    config.auth.use_persistent_session = True
+    client = NotebookLMClient(config)
+
+    page = FakePage()
+    context = FakeContext(pages=[page])
+    calls = []
+
+    class FakeChromium:
+        async def launch_persistent_context(self, **kwargs):
+            calls.append(dict(kwargs))
+            if "channel" in kwargs:
+                raise PWError("no system chrome installed")
+            return context
+
+    class FakePlaywrightWithChromium(FakePlaywright):
+        def __init__(self):
+            super().__init__()
+            self.chromium = FakeChromium()
+
+    monkeypatch.setattr(
+        "notebooklm_mcp.client.async_playwright",
+        make_async_playwright(FakePlaywrightWithChromium()),
     )
 
     await client.start()
-    assert called["start"] is True
+
+    assert client.page is page
+    assert len(calls) == 2
+    assert calls[0]["channel"] == "chrome"
+    assert "channel" not in calls[1]
 
 
-def test_get_current_response_fallback_text():
+# --------------------------------------------------------------------------- #
+# authenticate()
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_authenticate_requires_started_browser():
     client = NotebookLMClient(ServerConfig())
-
-    class FallbackDriver(DummyDriver):
-        def find_elements(self, _by, selector):
-            if selector == "p, div, span":
-                return [
-                    SimpleNamespace(text="menu"),
-                    SimpleNamespace(
-                        text="This is a very detailed answer explaining NotebookLM capabilities in depth."
-                    ),
-                ]
-            return []
-
-    client.driver = FallbackDriver()
-    assert "detailed answer" in client._get_current_response()
-
-
-def test_start_browser_uses_undetected_driver(monkeypatch, tmp_path):
-    config = ServerConfig()
-    config.auth.use_persistent_session = True
-    config.auth.profile_dir = str(tmp_path / "profile")
-    client = NotebookLMClient(config)
-
-    class DummyChromeOptions:
-        def __init__(self):
-            self.args = []
-
-        def add_argument(self, arg):
-            self.args.append(arg)
-
-    class DummyChromeDriver:
-        def __init__(self, options):
-            self.options = options
-            self.timeout = None
-
-        def set_page_load_timeout(self, timeout):
-            self.timeout = timeout
-
-    class DummyUCModule:
-        def ChromeOptions(self):
-            return DummyChromeOptions()
-
-        def Chrome(self, options=None, version_main=None):
-            return DummyChromeDriver(options)
-
-    monkeypatch.setattr("notebooklm_mcp.client.USE_UNDETECTED", True)
-    monkeypatch.setattr("notebooklm_mcp.client.uc", DummyUCModule(), raising=False)
-
-    client._start_browser()
-
-    assert client.driver.timeout == config.timeout
-    assert any("--user-data-dir" in arg for arg in client.driver.options.args)
-
-
-def test_start_regular_chrome_configures_options(monkeypatch):
-    config = ServerConfig(headless=True)
-    client = NotebookLMClient(config)
-
-    class DummyOptions:
-        def __init__(self):
-            self.arguments = []
-            self.experimental = {}
-
-        def add_argument(self, value):
-            self.arguments.append(value)
-
-        def add_experimental_option(self, name, value):
-            self.experimental[name] = value
-
-    class DummyDriver:
-        def __init__(self, options=None):
-            self.options = options
-            self.executed = []
-            self.timeout = None
-
-        def execute_script(self, script):
-            self.executed.append(script)
-
-        def set_page_load_timeout(self, timeout):
-            self.timeout = timeout
-
-    monkeypatch.setattr("notebooklm_mcp.client.ChromeOptions", DummyOptions)
-    monkeypatch.setattr(
-        "notebooklm_mcp.client.webdriver.Chrome",
-        lambda options=None: DummyDriver(options=options),
-    )
-    monkeypatch.setattr("notebooklm_mcp.client.USE_UNDETECTED", False)
-
-    client._start_browser()
-
-    assert "--no-sandbox" in client.driver.options.arguments
-    assert "--headless=new" in client.driver.options.arguments
-    assert any("webdriver" in call for call in client.driver.executed)
-    assert client.driver.timeout == config.timeout
-
-
-def test_start_browser_raises_when_driver_missing(monkeypatch):
-    client = NotebookLMClient(ServerConfig())
-
-    class DummyChromeOptions:
-        def __init__(self):
-            self.args = []
-
-        def add_argument(self, _value):
-            self.args.append(_value)
-
-    class DummyUCModule:
-        def ChromeOptions(self):
-            return DummyChromeOptions()
-
-        def Chrome(self, options=None, version_main=None):  # pragma: no cover - stub
-            return None
-
-    monkeypatch.setattr("notebooklm_mcp.client.USE_UNDETECTED", True)
-    monkeypatch.setattr("notebooklm_mcp.client.uc", DummyUCModule(), raising=False)
-
-    with pytest.raises(RuntimeError, match="Failed to initialize browser driver"):
-        client._start_browser()
-
-
-def test_authenticate_sync_success(monkeypatch):
-    config = ServerConfig()
-    client = NotebookLMClient(config)
-
-    class DummyDriver:
-        def __init__(self):
-            self.current_url = (
-                f"{config.base_url}/notebook/{config.default_notebook_id}"
-            )
-
-        def get(self, url):
-            self.current_url = url
-
-    class DummyWait:
-        def __init__(self, *_args, **_kwargs):
-            pass
-
-        def until(self, _condition):
-            return True
-
-    client.driver = DummyDriver()
-    monkeypatch.setattr("notebooklm_mcp.client.WebDriverWait", DummyWait)
-
-    assert client._authenticate_sync() is True
-    assert client._is_authenticated is True
-
-
-def test_authenticate_sync_requires_manual_login(monkeypatch):
-    config = ServerConfig(headless=False)
-    client = NotebookLMClient(config)
-    client.current_notebook_id = None
-
-    class DummyDriver:
-        def __init__(self):
-            self.current_url = "https://accounts.google.com/signin"
-
-        def get(self, url):
-            self.current_url = "https://accounts.google.com/signin"
-
-    class DummyWait:
-        def __init__(self, *_args, **_kwargs):
-            pass
-
-        def until(self, _condition):
-            return True
-
-    client.driver = DummyDriver()
-    monkeypatch.setattr("notebooklm_mcp.client.WebDriverWait", DummyWait)
-
-    assert client._authenticate_sync() is False
-    assert client._is_authenticated is False
-
-
-def test_authenticate_sync_timeout(monkeypatch):
-    client = NotebookLMClient(ServerConfig())
-    client.driver = SimpleNamespace(
-        get=lambda _url: None, current_url="https://notebooklm.google.com"
-    )
-
-    class TimeoutWait:
-        def __init__(self, *_args, **_kwargs):
-            pass
-
-        def until(self, _condition):
-            raise TimeoutException()
-
-    monkeypatch.setattr("notebooklm_mcp.client.WebDriverWait", TimeoutWait)
-
     with pytest.raises(AuthenticationError):
-        client._authenticate_sync()
+        await client.authenticate()
 
 
 @pytest.mark.asyncio
-async def test_get_response_requires_driver():
-    client = NotebookLMClient(ServerConfig())
+async def test_authenticate_signed_out_returns_false(client_factory):
+    page = FakePage(goto_url="https://accounts.google.com/signin")
+    client = client_factory(page=page, notebook_id="abc")
 
+    result = await client.authenticate()
+
+    assert result is False
+    assert client.is_authenticated is False
+
+
+@pytest.mark.asyncio
+async def test_authenticate_signin_path_marker_returns_false(client_factory):
+    """A ``/signin`` marker on the app host itself still reads as signed out
+    (kills an inversion of the signed-out check that would auth on this URL).
+    """
+    page = FakePage(goto_url="https://notebooklm.google.com/signin?foo=1")
+    client = client_factory(page=page, notebook_id="abc")
+
+    result = await client.authenticate()
+
+    assert result is False
+    assert client.is_authenticated is False
+
+
+@pytest.mark.asyncio
+async def test_authenticate_non_app_host_returns_false(client_factory):
+    page = FakePage(goto_url="https://example.com/whatever")
+    client = client_factory(page=page, notebook_id="abc")
+
+    result = await client.authenticate()
+
+    assert result is False
+    assert client.is_authenticated is False
+
+
+@pytest.mark.asyncio
+async def test_authenticate_app_host_with_notebook_returns_true(client_factory):
+    """REAL ``_find_first`` runs against a page that exposes the composer via
+    the first CHAT_INPUT selector; auth succeeds and the composer is confirmed.
+    """
+    composer = FakeElement(visible=True)
+    page = FakePage(
+        url="https://notebooklm.google.com/notebook/abc",
+        goto_url="https://notebooklm.google.com/notebook/abc",
+        selectors={S.CHAT_INPUT[0]: [composer]},
+    )
+    client = client_factory(page=page, notebook_id="abc")
+
+    result = await client.authenticate()
+
+    assert result is True
+    assert client.is_authenticated is True
+    assert page.goto_calls == ["https://notebooklm.google.com/notebook/abc"]
+    # The real _find_first actually probed the composer selector.
+    assert S.CHAT_INPUT[0] in page.locator_calls
+
+
+@pytest.mark.asyncio
+async def test_authenticate_no_notebook_skips_composer_probe(client_factory):
+    """No notebook loaded -> the composer best-effort path is skipped, but auth
+    on the app host still succeeds (covers the 199->203 branch skip).
+    """
+    page = FakePage(
+        url="https://notebooklm.google.com",
+        goto_url="https://notebooklm.google.com",
+    )
+    client = client_factory(page=page, notebook_id=None)
+    client.current_notebook_id = None
+
+    result = await client.authenticate()
+
+    assert result is True
+    assert client.is_authenticated is True
+    # No composer probe happened.
+    assert page.locator_calls == []
+
+
+@pytest.mark.asyncio
+async def test_authenticate_tolerates_missing_composer(no_sleep, client_factory):
+    """Composer never becomes visible -> REAL ``_find_first`` returns None after
+    exhausting CHAT_INPUT; that is only a warning, so auth still succeeds.
+    """
+    page = FakePage(
+        url="https://notebooklm.google.com/notebook/abc",
+        goto_url="https://notebooklm.google.com/notebook/abc",
+        # No CHAT_INPUT selectors registered -> every wait_for times out.
+    )
+    client = client_factory(page=page, notebook_id="abc")
+
+    assert await client.authenticate() is True
+    assert client.is_authenticated is True
+    # The real _find_first probed every CHAT_INPUT candidate before giving up.
+    for selector in S.CHAT_INPUT:
+        assert selector in page.locator_calls
+
+
+@pytest.mark.asyncio
+async def test_authenticate_goto_timeout_raises(client_factory):
+    page = FakePage(goto_error=PWTimeout("page load timed out"))
+    client = client_factory(page=page, notebook_id="abc")
+
+    with pytest.raises(AuthenticationError):
+        await client.authenticate()
+
+
+# --------------------------------------------------------------------------- #
+# send_message()
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_send_message_requires_page():
+    client = NotebookLMClient(ServerConfig())
+    client._is_authenticated = True
+    with pytest.raises(ChatError):
+        await client.send_message("hi")
+
+
+@pytest.mark.asyncio
+async def test_send_message_requires_authentication(client_factory):
+    client = client_factory(page=FakePage(), authenticated=False)
+    with pytest.raises(ChatError):
+        await client.send_message("hi")
+
+
+@pytest.mark.asyncio
+async def test_send_message_no_composer_raises(no_sleep, client_factory):
+    """No composer anywhere -> REAL ``_find_first`` returns None -> ChatError."""
+    # Already on the notebook so _ensure_on_notebook is a no-op (no goto needed).
+    page = FakePage(url="https://notebooklm.google.com/notebook/abc")
+    client = client_factory(page=page, notebook_id="abc", authenticated=True)
+
+    with pytest.raises(ChatError, match="Could not find chat input"):
+        await client.send_message("hi")
+
+
+@pytest.mark.asyncio
+async def test_send_message_happy_path_drives_real_find_first(client_factory):
+    """The REAL ``_find_first`` must pick the chat composer
+    (``textarea.query-box-input``) and the composer -- not anything else --
+    receives click -> fill -> press in order.
+    """
+    # Pre-built locator (via ``locators=``) so call ordering is recorded on the
+    # exact object the client interacts with.
+    composer = FakeLocator(elements=[FakeElement(visible=True)])
+    page = FakePage(
+        url="https://notebooklm.google.com/notebook/abc",
+        locators={S.CHAT_INPUT[0]: composer},
+    )
+    client = client_factory(page=page, notebook_id="abc", authenticated=True)
+
+    await client.send_message("hello world")
+
+    # _find_first wait_for's the composer first, then click/fill/press in order.
+    assert composer.calls == [
+        "wait_for",
+        "click",
+        ("fill", "hello world"),
+        ("press", "Enter"),
+    ]
+    # And the very first selector probed was the verified composer selector.
+    assert page.locator_calls[0] == S.CHAT_INPUT[0]
+
+
+@pytest.mark.asyncio
+async def test_send_message_picks_composer_not_decoy(client_factory):
+    """Page has a DECOY textarea (a non-CHAT_INPUT selector) AND the real
+    ``query-box-input``. ``_find_first`` must select the composer via the
+    selector list -- never the decoy. Proven by checking the composer received
+    the keystrokes and the decoy did not.
+    """
+    # A visible decoy that would win under any blind catch-all, but its selector
+    # is NOT in S.CHAT_INPUT.
+    decoy = FakeLocator(elements=[FakeElement(text="decoy", visible=True)])
+    composer = FakeLocator(elements=[FakeElement(visible=True)])
+    page = FakePage(
+        url="https://notebooklm.google.com/notebook/abc",
+        locators={
+            "textarea:not([disabled])": decoy,  # the deliberately-excluded one
+            S.CHAT_INPUT[0]: composer,
+        },
+    )
+    client = client_factory(page=page, notebook_id="abc", authenticated=True)
+
+    await client.send_message("payload")
+
+    # The composer got the full interaction...
+    assert composer.calls == [
+        "wait_for",
+        "click",
+        ("fill", "payload"),
+        ("press", "Enter"),
+    ]
+    # ...and the decoy was never touched.
+    assert decoy.calls == []
+
+
+@pytest.mark.asyncio
+async def test_send_message_falls_through_to_second_selector(client_factory):
+    """First CHAT_INPUT selector matches nothing visible; ``_find_first`` falls
+    through to the second candidate, which is the one that gets used.
+    """
+    second = FakeLocator(elements=[FakeElement(visible=True)])
+    page = FakePage(
+        url="https://notebooklm.google.com/notebook/abc",
+        locators={
+            # S.CHAT_INPUT[0] intentionally absent -> empty match -> timeout.
+            S.CHAT_INPUT[1]: second,
+        },
+    )
+    client = client_factory(page=page, notebook_id="abc", authenticated=True)
+
+    await client.send_message("payload")
+
+    assert second.calls == [
+        "wait_for",
+        "click",
+        ("fill", "payload"),
+        ("press", "Enter"),
+    ]
+    # The first selector was probed before falling through.
+    assert page.locator_calls[0] == S.CHAT_INPUT[0]
+    assert S.CHAT_INPUT[1] in page.locator_calls
+
+
+@pytest.mark.asyncio
+async def test_send_message_press_error_raises_chaterror(client_factory):
+    composer = FakeLocator(
+        elements=[FakeElement(visible=True, raise_on={"press": PWError("detached")})]
+    )
+    page = FakePage(
+        url="https://notebooklm.google.com/notebook/abc",
+        locators={S.CHAT_INPUT[0]: composer},
+    )
+    client = client_factory(page=page, notebook_id="abc", authenticated=True)
+
+    with pytest.raises(ChatError, match="Failed to submit message"):
+        await client.send_message("hi")
+
+
+@pytest.mark.asyncio
+async def test_send_message_no_notebook_skips_navigation(client_factory):
+    """No ``current_notebook_id`` -> ``_ensure_on_notebook`` returns early with
+    no goto (covers the client.py:234-235 early-return), and the composer is
+    still located and used.
+    """
+    composer = FakeLocator(elements=[FakeElement(visible=True)])
+    page = FakePage(
+        url="https://notebooklm.google.com",
+        locators={S.CHAT_INPUT[0]: composer},
+    )
+    client = client_factory(page=page, authenticated=True)
+    client.current_notebook_id = None
+
+    await client.send_message("payload")
+
+    assert page.goto_calls == []  # no navigation attempted
+    assert composer.calls == [
+        "wait_for",
+        "click",
+        ("fill", "payload"),
+        ("press", "Enter"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_send_message_navigates_when_off_notebook(client_factory):
+    """When the page URL is not on the target notebook, ``_ensure_on_notebook``
+    triggers a real navigation before the composer is used.
+    """
+    composer = FakeLocator(elements=[FakeElement(visible=True)])
+    page = FakePage(
+        url="https://notebooklm.google.com/somewhere-else",
+        goto_url="https://notebooklm.google.com/notebook/abc",
+        locators={S.CHAT_INPUT[0]: composer},
+    )
+    client = client_factory(page=page, notebook_id="abc", authenticated=True)
+
+    await client.send_message("payload")
+
+    assert page.goto_calls == ["https://notebooklm.google.com/notebook/abc"]
+    assert composer.calls[0] == "wait_for"
+
+
+# --------------------------------------------------------------------------- #
+# get_response()
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_get_response_requires_page():
+    client = NotebookLMClient(ServerConfig())
     with pytest.raises(ChatError):
         await client.get_response()
 
 
-def test_send_message_sync_submit_failure(monkeypatch):
-    client = NotebookLMClient(ServerConfig(default_notebook_id="abc"))
-    driver = DummyDriver()
-    driver.current_url = "https://notebooklm.google.com/notebook/abc"
-    client.driver = driver
+@pytest.mark.asyncio
+async def test_get_response_no_wait_returns_latest():
+    """REAL ``_read_latest_response`` reads the newest bubble (no wait path)."""
+    page = FakePage(
+        selectors={S.RESPONSE[0]: [FakeElement(text="the latest answer")]},
+    )
+    client = NotebookLMClient(ServerConfig())
+    client.page = page
 
-    class DummyWait:
-        def __init__(self, *_args, **_kwargs):
-            pass
+    result = await client.get_response(wait_for_completion=False)
+    assert result == "the latest answer"
 
-        def until(self, _condition):
-            class FailingInput:
-                def __init__(self):
-                    self.values = []
 
-                def clear(self):
-                    pass
+@pytest.mark.asyncio
+async def test_get_response_empty_returns_placeholder():
+    """No response bubbles -> REAL ``_read_latest_response`` returns "" ->
+    placeholder.
+    """
+    page = FakePage(selectors={})
+    client = NotebookLMClient(ServerConfig())
+    client.page = page
 
-                def send_keys(self, value):
-                    self.values.append(value)
-                    if value == "RETURN":
-                        raise RuntimeError("fail")
+    result = await client.get_response(wait_for_completion=False)
+    assert result == "No response content found"
 
-            return FailingInput()
 
-    monkeypatch.setattr("notebooklm_mcp.client.WebDriverWait", DummyWait)
-    monkeypatch.setattr(
-        "selenium.webdriver.common.keys.Keys.RETURN",
-        "RETURN",
-        raising=False,
+@pytest.mark.asyncio
+async def test_get_response_wait_path_runs_real_stability_loop(no_sleep):
+    """Drive the REAL ``_wait_until_idle`` + REAL ``_read_latest_response`` +
+    REAL ``_is_thinking``:
+
+    * the response text changes over the first polls, then stabilizes;
+    * the thinking indicator is visible at first, then flips hidden.
+
+    The loop must only return once thinking has cleared AND the text has been
+    stable for ``response_stability_checks`` polls.
+    """
+    config = ServerConfig(response_stability_checks=2, streaming_timeout=60)
+    client = NotebookLMClient(config)
+
+    # Each call to page.locator() advances the shared poll counter by 1. Per
+    # poll iteration of _wait_until_idle, locator() is called once for the
+    # RESPONSE read and once (per visible THINKING selector probe) for thinking.
+    # Use generous timelines that converge to a stable answer and a cleared
+    # thinking indicator.
+    response_text = [
+        "Partial",  # poll 1
+        "Partial answer",  # poll 2  (changed -> resets stable)
+        "Final answer",  # poll 3  (changed -> resets stable)
+        "Final answer",  # poll 4  (stable #1)  thinking still on early
+        "Final answer",  # poll 5
+        "Final answer",  # poll 6
+        "Final answer",  # subsequent polls stick on last value
+    ]
+    # Thinking visible for the early polls, then hidden.
+    thinking_visible = [True, True, True, True, False, False, False]
+
+    page = FakePage(
+        selectors={
+            S.RESPONSE[0]: [FakeElement(text=response_text)],
+            S.THINKING[0]: [FakeElement(visible=thinking_visible)],
+        },
+    )
+    client.page = page
+
+    result = await client.get_response(wait_for_completion=True)
+
+    assert result == "Final answer"
+
+
+@pytest.mark.asyncio
+async def test_get_response_does_not_return_while_thinking(no_sleep):
+    """Even with stable text, the loop must NOT return while the thinking
+    indicator is still visible. It returns only after thinking clears.
+
+    Kills a mutation that drops the ``not thinking`` guard: with stable text and
+    ``response_stability_checks=1`` the stability count is satisfied by poll #2,
+    so an implementation that ignored ``thinking`` would return then. The real
+    loop must keep polling until ``thinking`` flips hidden at poll #5, producing
+    strictly more RESPONSE reads.
+    """
+    config = ServerConfig(response_stability_checks=1, streaming_timeout=60)
+    client = NotebookLMClient(config)
+
+    # Text is stable from the very first poll (so the stability count of 1 is
+    # met as soon as the second poll), but the thinking indicator stays visible
+    # well past that point. Each poll iteration probes RESPONSE then THINKING, so
+    # the THINKING check on poll-iteration K sees the (2*K)-th sequenced value;
+    # keeping the timeline ``True`` through index 7 means thinking only clears on
+    # poll-iteration #4. A correct loop therefore performs >= 4 RESPONSE reads,
+    # while a mutation that ignores ``thinking`` returns at iteration #2 (only
+    # 2 reads) -- killing it.
+    thinking_timeline = [True] * 8 + [False]
+    page = FakePage(
+        selectors={
+            S.RESPONSE[0]: [FakeElement(text="stable from the start")],
+            S.THINKING[0]: [FakeElement(visible=thinking_timeline)],
+        },
+    )
+    client.page = page
+
+    await client.get_response(wait_for_completion=True)
+
+    response_reads = [c for c in page.locator_calls if c == S.RESPONSE[0]]
+    assert len(response_reads) >= 4
+
+
+# --------------------------------------------------------------------------- #
+# _wait_until_idle()
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_wait_until_idle_times_out_without_error(no_sleep):
+    """Stays 'thinking' the whole time; loop exits cleanly on deadline.
+
+    Runs the REAL ``_read_latest_response`` and ``_is_thinking``.
+    """
+    config = ServerConfig(response_stability_checks=2)
+    client = NotebookLMClient(config)
+    page = FakePage(
+        selectors={
+            S.RESPONSE[0]: [FakeElement(text="still streaming")],
+            S.THINKING[0]: [FakeElement(visible=True)],  # never settles
+        },
+    )
+    client.page = page
+
+    # Small budget so the deadline is hit immediately. Returns None, no raise.
+    assert await client._wait_until_idle(max_wait=0) is None
+
+
+@pytest.mark.asyncio
+async def test_wait_until_idle_requires_stability_count(no_sleep):
+    """With ``response_stability_checks=3`` and no thinking, the loop must see
+    the SAME text three consecutive polls before returning. Proven by counting
+    RESPONSE reads (>= 3).
+    """
+    config = ServerConfig(response_stability_checks=3, streaming_timeout=60)
+    client = NotebookLMClient(config)
+    page = FakePage(
+        selectors={
+            S.RESPONSE[0]: [FakeElement(text="done")],  # stable immediately
+            # No THINKING selector -> _is_thinking is always False.
+        },
+    )
+    client.page = page
+
+    await client._wait_until_idle(max_wait=60)
+
+    response_reads = [c for c in page.locator_calls if c == S.RESPONSE[0]]
+    assert len(response_reads) >= 3
+
+
+# --------------------------------------------------------------------------- #
+# _read_latest_response()
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_read_latest_response_picks_last_element():
+    """Three matching elements; the LAST (index count-1) provides the text.
+
+    This is the ``nth(count - 1)`` indexing -- a mutation to ``nth(0)`` reads
+    "oldest" and fails this assertion.
+    """
+    elements = [
+        FakeElement(text="oldest message"),
+        FakeElement(text="middle message"),
+        FakeElement(text="newest message"),
+    ]
+    page = FakePage(selectors={S.RESPONSE[0]: elements})
+    client = NotebookLMClient(ServerConfig())
+    client.page = page
+
+    text = await client._read_latest_response()
+    assert text == "newest message"
+
+
+@pytest.mark.asyncio
+async def test_read_latest_response_falls_through_selector_groups():
+    """First RESPONSE group matches nothing; logic falls through to the second
+    group and reads the last element there.
+    """
+    page = FakePage(
+        selectors={
+            # S.RESPONSE[0] absent -> count 0 -> skip.
+            S.RESPONSE[1]: [
+                FakeElement(text="from second group A"),
+                FakeElement(text="from second group B"),
+            ],
+        },
+    )
+    client = NotebookLMClient(ServerConfig())
+    client.page = page
+
+    text = await client._read_latest_response()
+    assert text == "from second group B"
+
+
+@pytest.mark.asyncio
+async def test_read_latest_response_skips_blank_then_returns_next_group():
+    """A matched element whose text is whitespace-only is not returned; the
+    loop moves to the next group and returns its non-blank text.
+    """
+    page = FakePage(
+        selectors={
+            S.RESPONSE[0]: [FakeElement(text="   \n  ")],  # blank -> skipped
+            S.RESPONSE[1]: [FakeElement(text="real content")],
+        },
+    )
+    client = NotebookLMClient(ServerConfig())
+    client.page = page
+
+    text = await client._read_latest_response()
+    assert text == "real content"
+
+
+@pytest.mark.asyncio
+async def test_read_latest_response_returns_empty_when_none():
+    """No selector matches anything -> "" (all default empty matches)."""
+    page = FakePage(selectors={})
+    client = NotebookLMClient(ServerConfig())
+    client.page = page
+
+    assert await client._read_latest_response() == ""
+
+
+@pytest.mark.asyncio
+async def test_read_latest_response_continues_on_playwright_error():
+    """A selector group that raises a Playwright error mid-read is swallowed and
+    the next group is tried (exercises the ``except PlaywrightError: continue``).
+    """
+    # The first group's element raises a real PlaywrightError on inner_text.
+    raising = FakeElement(text="boom", raise_on={"inner_text": PWError("detached")})
+    page = FakePage(
+        selectors={
+            S.RESPONSE[0]: [raising],
+            S.RESPONSE[1]: [FakeElement(text="recovered")],
+        },
+    )
+    client = NotebookLMClient(ServerConfig())
+    client.page = page
+
+    assert await client._read_latest_response() == "recovered"
+
+
+@pytest.mark.asyncio
+async def test_read_latest_response_returns_empty_when_no_page():
+    client = NotebookLMClient(ServerConfig())
+    assert await client._read_latest_response() == ""
+
+
+# --------------------------------------------------------------------------- #
+# _is_thinking()
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_is_thinking_true_when_indicator_visible():
+    page = FakePage(selectors={S.THINKING[0]: [FakeElement(visible=True)]})
+    client = NotebookLMClient(ServerConfig())
+    client.page = page
+
+    assert await client._is_thinking() is True
+
+
+@pytest.mark.asyncio
+async def test_is_thinking_falls_through_to_later_selector():
+    """First THINKING selector has no visible node; a LATER selector does.
+    The real loop must keep scanning rather than stop at the first group.
+    """
+    page = FakePage(
+        selectors={
+            # S.THINKING[0] absent -> not visible.
+            S.THINKING[1]: [FakeElement(visible=True)],
+        },
+    )
+    client = NotebookLMClient(ServerConfig())
+    client.page = page
+
+    assert await client._is_thinking() is True
+
+
+@pytest.mark.asyncio
+async def test_is_thinking_false_when_no_indicator():
+    page = FakePage(selectors={})  # all selectors match nothing visible
+    client = NotebookLMClient(ServerConfig())
+    client.page = page
+
+    assert await client._is_thinking() is False
+
+
+@pytest.mark.asyncio
+async def test_is_thinking_continues_on_playwright_error():
+    """A selector whose visibility probe raises is swallowed; scanning
+    continues to a later selector that is visible.
+    """
+    raising = FakeElement(visible=True, raise_on={"is_visible": PWError("detached")})
+    page = FakePage(
+        selectors={
+            S.THINKING[0]: [raising],
+            S.THINKING[1]: [FakeElement(visible=True)],
+        },
+    )
+    client = NotebookLMClient(ServerConfig())
+    client.page = page
+
+    assert await client._is_thinking() is True
+
+
+@pytest.mark.asyncio
+async def test_is_thinking_false_when_no_page():
+    client = NotebookLMClient(ServerConfig())
+    assert await client._is_thinking() is False
+
+
+# --------------------------------------------------------------------------- #
+# _find_first() -- direct coverage of the real selector loop
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_find_first_returns_none_when_no_page():
+    client = NotebookLMClient(ServerConfig())
+    assert await client._find_first(S.CHAT_INPUT, timeout=1000) is None
+
+
+@pytest.mark.asyncio
+async def test_find_first_waits_for_visible_then_returns_it(no_sleep):
+    """The real ``_find_first`` must ``wait_for`` each candidate and only return
+    one that becomes visible -- not blindly return the first selector's locator.
+    """
+    visible = FakeLocator(elements=[FakeElement(visible=True)])
+    page = FakePage(
+        locators={
+            # First candidate matches nothing -> wait_for times out.
+            S.CHAT_INPUT[1]: visible,
+        },
+    )
+    client = NotebookLMClient(ServerConfig())
+    client.page = page
+
+    result = await client._find_first(S.CHAT_INPUT, timeout=4000)
+
+    # _find_first returns ``locator.first`` (a scoped view sharing the same
+    # element + call log as ``visible``).
+    assert result is not None
+    assert result.calls is visible.calls
+    # It actually awaited visibility (not a blind return).
+    assert "wait_for" in visible.calls
+    # The first candidate was probed and timed out before falling through.
+    assert page.locator_calls[0] == S.CHAT_INPUT[0]
+    # It returned a view of the second (visible) candidate, not the first.
+    assert page.locator_calls.index(S.CHAT_INPUT[0]) < page.locator_calls.index(
+        S.CHAT_INPUT[1]
     )
 
-    with pytest.raises(ChatError, match="Failed to submit message"):
-        client._send_message_sync("hello")
+
+@pytest.mark.asyncio
+async def test_find_first_returns_none_when_nothing_visible(no_sleep):
+    page = FakePage(locators={})  # nothing visible anywhere
+    client = NotebookLMClient(ServerConfig())
+    client.page = page
+
+    assert await client._find_first(S.CHAT_INPUT, timeout=2000) is None
+    # Every candidate was probed.
+    for selector in S.CHAT_INPUT:
+        assert selector in page.locator_calls
 
 
-def test_wait_for_streaming_response_timeout(monkeypatch):
-    client = NotebookLMClient(ServerConfig(response_stability_checks=2))
-
-    monkeypatch.setattr(
-        client,
-        "_get_current_response",
-        MethodType(lambda self: "", client),
+@pytest.mark.asyncio
+async def test_find_first_swallows_generic_playwright_error(no_sleep):
+    """A candidate whose ``wait_for`` raises a generic (non-timeout) Playwright
+    error is swallowed; scanning continues to a visible candidate.
+    """
+    erroring = FakeLocator(
+        elements=[FakeElement(visible=False, raise_on={"wait_for": PWError("boom")})]
     )
-    monkeypatch.setattr(
-        client,
-        "_check_streaming_indicators",
-        MethodType(lambda self: True, client),
+    visible = FakeLocator(elements=[FakeElement(visible=True)])
+    page = FakePage(
+        locators={
+            S.CHAT_INPUT[0]: erroring,
+            S.CHAT_INPUT[1]: visible,
+        },
     )
+    client = NotebookLMClient(ServerConfig())
+    client.page = page
 
-    sequence = iter([0.0, 0.5, 1.1])
-    monkeypatch.setattr("notebooklm_mcp.client.time.time", lambda: next(sequence, 2.0))
-    monkeypatch.setattr("notebooklm_mcp.client.time.sleep", lambda _s: None)
+    result = await client._find_first(S.CHAT_INPUT, timeout=4000)
+    assert result is not None
+    assert result.calls is visible.calls
+    assert "wait_for" in visible.calls
 
-    result = client._wait_for_streaming_response(max_wait=1)
-    assert "timeout" in result.lower()
+
+# --------------------------------------------------------------------------- #
+# navigate_to_notebook()
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_navigate_to_notebook_requires_page():
+    client = NotebookLMClient(ServerConfig())
+    with pytest.raises(NavigationError):
+        await client.navigate_to_notebook("xyz")
+
+
+@pytest.mark.asyncio
+async def test_navigate_to_notebook_success(client_factory):
+    page = FakePage()  # goto echoes the requested URL
+    client = client_factory(page=page, notebook_id="old")
+
+    url = await client.navigate_to_notebook("new-id")
+
+    assert client.current_notebook_id == "new-id"
+    assert url == "https://notebooklm.google.com/notebook/new-id"
+    assert page.goto_calls == ["https://notebooklm.google.com/notebook/new-id"]
+
+
+@pytest.mark.asyncio
+async def test_navigate_to_notebook_timeout_raises(client_factory):
+    page = FakePage(goto_error=PWTimeout("nav timed out"))
+    client = client_factory(page=page, notebook_id="old")
+
+    with pytest.raises(NavigationError):
+        await client.navigate_to_notebook("new-id")
+
+
+# --------------------------------------------------------------------------- #
+# close() / driver / is_authenticated
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_close_is_safe_with_no_page():
+    client = NotebookLMClient(ServerConfig())
+    client._is_authenticated = True
+
+    await client.close()
+
+    assert client._is_authenticated is False
+    assert client.page is None
+
+
+@pytest.mark.asyncio
+async def test_close_shuts_down_and_resets(client_factory):
+    page = FakePage()
+    context = FakeContext(pages=[page])
+    playwright = FakePlaywright()
+    client = client_factory(page=page, authenticated=True)
+    client.context = context
+    client._playwright = playwright
+
+    await client.close()
+
+    assert context.closed is True
+    assert playwright.stopped is True
+    assert client.page is None
+    assert client.context is None
+    assert client._playwright is None
+    assert client.is_authenticated is False
+
+
+def test_driver_property_returns_page():
+    client = NotebookLMClient(ServerConfig())
+    assert client.driver is None
+    page = FakePage()
+    client.page = page
+    assert client.driver is page

--- a/tests/test_client_rpc.py
+++ b/tests/test_client_rpc.py
@@ -1,0 +1,628 @@
+"""Deterministic tests for the RPC engine (:mod:`notebooklm_mcp.client_rpc`).
+
+The RPC client wraps ``notebooklm-py`` via the module-level
+``_backend_class()`` indirection. These tests **never import real
+notebooklm-py and never touch a browser/network**: we monkeypatch
+``client_rpc._backend_class`` to return a *faithful* fake backend whose async
+surface mirrors the real one (``from_storage`` async context manager exposing
+``notebooks`` / ``sources`` / ``chat`` sub-APIs). The production client logic
+(``start``/``authenticate``/``send_message``/management methods) runs unchanged
+against the fake -- so a mutation in the real client logic is caught here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from notebooklm_mcp import auth_bridge, client_rpc
+from notebooklm_mcp.client_rpc import (
+    NotebookLMRPCClient,
+    _notebook_dict,
+    _source_dict,
+)
+from notebooklm_mcp.config import AuthConfig, ServerConfig
+from notebooklm_mcp.exceptions import ChatError, NavigationError
+
+
+# --------------------------------------------------------------------------- #
+# Faithful fake notebooklm-py backend.
+#
+# The real backend is opened via ``NotebookLMClient.from_storage(path=...)``,
+# which is an async context manager. Its ``__aenter__`` yields an object with
+# ``.notebooks`` / ``.sources`` / ``.chat`` sub-APIs whose methods are all
+# coroutines. The fakes below model exactly that shape and record every call so
+# tests can assert the client forwards the right method + args. Backend data
+# lives in private attrs; the public ``.notebooks`` / ``.sources`` / ``.chat``
+# names are the sub-API objects (matching the real surface the client uses).
+# --------------------------------------------------------------------------- #
+class _Backend:
+    """Faithful fake backend: data in private attrs, sub-APIs public."""
+
+    def __init__(
+        self,
+        *,
+        notebooks=None,
+        sources=None,
+        summary="A summary",
+        ask_result=None,
+        list_error=None,
+        ask_error=None,
+    ):
+        self.calls: list[tuple] = []
+        self._notebooks_data = list(notebooks) if notebooks is not None else []
+        self._sources_data = list(sources) if sources is not None else []
+        self.summary = summary
+        self.ask_result = (
+            ask_result
+            if ask_result is not None
+            else SimpleNamespace(answer="default-answer")
+        )
+        self.list_error = list_error
+        self.ask_error = ask_error
+        self.notebooks = _NotebooksAPI(self)
+        self.sources = _SourcesAPI(self)
+        self.chat = _ChatAPI(self)
+
+
+class _NotebooksAPI:
+    def __init__(self, backend):
+        self._b = backend
+
+    async def list(self):
+        self._b.calls.append(("notebooks.list",))
+        if self._b.list_error is not None:
+            raise self._b.list_error
+        return list(self._b._notebooks_data)
+
+    async def create(self, title):
+        self._b.calls.append(("notebooks.create", title))
+        return SimpleNamespace(id="nb-new", title=title, emoji="✨", source_count=0)
+
+    async def rename(self, notebook_id, new_title):
+        self._b.calls.append(("notebooks.rename", notebook_id, new_title))
+        return SimpleNamespace(
+            id=notebook_id, title=new_title, emoji="📓", source_count=2
+        )
+
+    async def delete(self, notebook_id):
+        self._b.calls.append(("notebooks.delete", notebook_id))
+        return None
+
+    async def get_summary(self, notebook_id):
+        self._b.calls.append(("notebooks.get_summary", notebook_id))
+        return self._b.summary
+
+
+class _SourcesAPI:
+    def __init__(self, backend):
+        self._b = backend
+
+    async def list(self, notebook_id):
+        self._b.calls.append(("sources.list", notebook_id))
+        return list(self._b._sources_data)
+
+    async def add_url(self, notebook_id, url):
+        self._b.calls.append(("sources.add_url", notebook_id, url))
+        return SimpleNamespace(id="src-url", title=url, type="url", status="processing")
+
+    async def add_text(self, notebook_id, title, text):
+        self._b.calls.append(("sources.add_text", notebook_id, title, text))
+        return SimpleNamespace(id="src-text", title=title, type="text", status="ready")
+
+    async def delete(self, notebook_id, source_id):
+        self._b.calls.append(("sources.delete", notebook_id, source_id))
+        return None
+
+
+class _ChatAPI:
+    def __init__(self, backend):
+        self._b = backend
+
+    async def ask(self, notebook_id, question):
+        self._b.calls.append(("chat.ask", notebook_id, question))
+        if self._b.ask_error is not None:
+            raise self._b.ask_error
+        return self._b.ask_result
+
+
+class _StorageCM:
+    """Async context manager returned by ``from_storage(path=...)``."""
+
+    def __init__(self, backend, opened_paths):
+        self._backend = backend
+        self._opened_paths = opened_paths
+        self.entered = False
+        self.exited = False
+
+    async def __aenter__(self):
+        self.entered = True
+        return self._backend
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self.exited = True
+        return False
+
+
+def make_backend_class(backend, opened_paths):
+    """Return a fake backend class whose ``from_storage`` yields ``backend``."""
+
+    class _FakeBackendClass:
+        @classmethod
+        def from_storage(cls, path):
+            opened_paths.append(path)
+            return _StorageCM(backend, opened_paths)
+
+    return _FakeBackendClass
+
+
+def install_backend(monkeypatch, backend):
+    """Patch ``_backend_class`` to hand out a fake class wrapping ``backend``.
+
+    Returns the list of paths ``from_storage`` was called with, so tests can
+    assert which storage_state path was used.
+    """
+    opened_paths: list = []
+    monkeypatch.setattr(
+        client_rpc,
+        "_backend_class",
+        lambda: make_backend_class(backend, opened_paths),
+    )
+    return opened_paths
+
+
+def make_config(tmp_path, **overrides):
+    """A ServerConfig whose profile_dir is an isolated tmp dir."""
+    auth = AuthConfig(profile_dir=str(tmp_path / "profile"))
+    cfg = ServerConfig(auth=auth, engine="rpc", **overrides)
+    return cfg
+
+
+async def started_client(monkeypatch, tmp_path, backend, *, storage_file=None):
+    """Build + start an RPC client against ``backend``.
+
+    A real ``storage_state`` file is created so ``_resolve_storage_state``
+    returns it directly (no bootstrap, no browser).
+    """
+    if storage_file is None:
+        storage_file = tmp_path / "profile" / "storage_state.json"
+        storage_file.parent.mkdir(parents=True, exist_ok=True)
+        storage_file.write_text("{}")
+    cfg = make_config(tmp_path)
+    client = NotebookLMRPCClient(cfg)
+    install_backend(monkeypatch, backend)
+    await client.start()
+    return client
+
+
+# --------------------------------------------------------------------------- #
+# Pure mapping helpers
+# --------------------------------------------------------------------------- #
+def test_notebook_dict_serializes_all_fields():
+    nb = SimpleNamespace(id="n1", title="T", emoji="📘", source_count=5)
+    assert _notebook_dict(nb) == {
+        "id": "n1",
+        "title": "T",
+        "emoji": "📘",
+        "source_count": 5,
+    }
+
+
+def test_notebook_dict_tolerates_missing_attrs():
+    # An object missing every attribute must map every field to None (not crash
+    # and not invent values).
+    assert _notebook_dict(object()) == {
+        "id": None,
+        "title": None,
+        "emoji": None,
+        "source_count": None,
+    }
+
+
+def test_source_dict_serializes_and_prefers_type():
+    src = SimpleNamespace(id="s1", title="Doc", type="pdf", status="ready")
+    assert _source_dict(src) == {
+        "id": "s1",
+        "title": "Doc",
+        "type": "pdf",
+        "status": "ready",
+    }
+
+
+def test_source_dict_falls_back_to_source_type():
+    # When ``type`` is absent the mapper must fall back to ``source_type``.
+    src = SimpleNamespace(id="s2", title="Doc", source_type="website", status="ok")
+    assert _source_dict(src)["type"] == "website"
+
+
+def test_source_dict_tolerates_missing_attrs():
+    assert _source_dict(object()) == {
+        "id": None,
+        "title": None,
+        "type": None,
+        "status": None,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Engine flags / trivial properties
+# --------------------------------------------------------------------------- #
+def test_supports_management_is_true():
+    assert NotebookLMRPCClient.supports_management is True
+
+
+def test_driver_is_none_and_default_notebook_seeded():
+    cfg = ServerConfig(engine="rpc", default_notebook_id="seed")
+    client = NotebookLMRPCClient(cfg)
+    assert client.driver is None
+    assert client.current_notebook_id == "seed"
+    assert client.is_authenticated is False
+
+
+# --------------------------------------------------------------------------- #
+# start() lifecycle + idempotency
+# --------------------------------------------------------------------------- #
+def test_start_enters_context_and_stores_backend(tmp_path, monkeypatch):
+    backend = _Backend()
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+    # The backend the client holds is exactly the one yielded by __aenter__.
+    assert client._backend is backend
+    assert client._cm is not None and client._cm.entered is True
+
+
+def test_start_is_idempotent(tmp_path, monkeypatch):
+    backend = _Backend()
+    storage_file = tmp_path / "profile" / "storage_state.json"
+    storage_file.parent.mkdir(parents=True, exist_ok=True)
+    storage_file.write_text("{}")
+    cfg = make_config(tmp_path)
+    client = NotebookLMRPCClient(cfg)
+    opened = install_backend(monkeypatch, backend)
+
+    asyncio.run(client.start())
+    first_backend = client._backend
+    asyncio.run(client.start())
+    # Second start is a no-op: backend unchanged, from_storage called once.
+    assert client._backend is first_backend
+    assert len(opened) == 1
+
+
+# --------------------------------------------------------------------------- #
+# _resolve_storage_state
+# --------------------------------------------------------------------------- #
+def test_resolve_storage_state_explicit_existing(tmp_path, monkeypatch):
+    explicit = tmp_path / "explicit_state.json"
+    explicit.write_text("{}")
+    cfg = make_config(tmp_path)
+    cfg.auth.storage_state_path = str(explicit)
+    client = NotebookLMRPCClient(cfg)
+
+    resolved = asyncio.run(client._resolve_storage_state())
+    assert resolved == explicit
+
+
+def test_resolve_storage_state_explicit_missing_falls_through(tmp_path, monkeypatch):
+    # Explicit path that does NOT exist must be ignored; resolution then falls
+    # through to the default-path branch (which here exists).
+    missing = tmp_path / "nope.json"
+    cfg = make_config(tmp_path)
+    cfg.auth.storage_state_path = str(missing)
+    # Make the default path exist so we land on the default branch, not bootstrap.
+    default_file = tmp_path / "default_state.json"
+    default_file.write_text("{}")
+    # _resolve_storage_state does `from .auth_bridge import default_storage_state_path`
+    # at call time, so patching the source module symbol is what takes effect.
+    monkeypatch.setattr(
+        auth_bridge, "default_storage_state_path", lambda _cfg: default_file
+    )
+
+    client = NotebookLMRPCClient(cfg)
+    resolved = asyncio.run(client._resolve_storage_state())
+    assert resolved == default_file
+
+
+def test_resolve_storage_state_default_path_exists(tmp_path, monkeypatch):
+    default_file = tmp_path / "default_state.json"
+    default_file.write_text("{}")
+    monkeypatch.setattr(
+        auth_bridge, "default_storage_state_path", lambda _cfg: default_file
+    )
+
+    async def _should_not_run(*_a, **_k):  # pragma: no cover - must NOT be called
+        raise AssertionError("export_storage_state must not run when default exists")
+
+    monkeypatch.setattr(auth_bridge, "export_storage_state", _should_not_run)
+
+    cfg = make_config(tmp_path)
+    client = NotebookLMRPCClient(cfg)
+    resolved = asyncio.run(client._resolve_storage_state())
+    assert resolved == default_file
+
+
+def test_resolve_storage_state_bootstraps_when_missing(tmp_path, monkeypatch):
+    # No explicit path, default path does NOT exist -> must call
+    # export_storage_state (the one-time bootstrap) and return its result.
+    target = tmp_path / "profile" / "storage_state.json"
+    bootstrapped = tmp_path / "bootstrapped.json"
+    bootstrapped.write_text("{}")
+    monkeypatch.setattr(auth_bridge, "default_storage_state_path", lambda _cfg: target)
+
+    export_calls = []
+
+    async def fake_export(config, out_path):
+        export_calls.append((config, out_path))
+        return bootstrapped
+
+    monkeypatch.setattr(auth_bridge, "export_storage_state", fake_export)
+
+    cfg = make_config(tmp_path)
+    client = NotebookLMRPCClient(cfg)
+    resolved = asyncio.run(client._resolve_storage_state())
+
+    assert resolved == bootstrapped
+    # export was called once, with the config and the default target path.
+    assert len(export_calls) == 1
+    assert export_calls[0][0] is cfg
+    assert export_calls[0][1] == target
+
+
+# --------------------------------------------------------------------------- #
+# authenticate()
+# --------------------------------------------------------------------------- #
+def test_authenticate_success(tmp_path, monkeypatch):
+    backend = _Backend(notebooks=[SimpleNamespace(id="n", title="t")])
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    result = asyncio.run(client.authenticate())
+    assert result is True
+    assert client.is_authenticated is True
+    # The cheap auth probe is a notebooks.list call.
+    assert ("notebooks.list",) in backend.calls
+
+
+def test_authenticate_failure_when_list_raises(tmp_path, monkeypatch):
+    backend = _Backend(list_error=RuntimeError("401 unauthorized"))
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    result = asyncio.run(client.authenticate())
+    assert result is False
+    assert client.is_authenticated is False
+
+
+def test_authenticate_without_backend_raises(tmp_path):
+    cfg = make_config(tmp_path)
+    client = NotebookLMRPCClient(cfg)
+    # Never started -> _require_backend raises ChatError.
+    with pytest.raises(ChatError, match="not started"):
+        asyncio.run(client.authenticate())
+
+
+# --------------------------------------------------------------------------- #
+# Chat surface
+# --------------------------------------------------------------------------- #
+def test_send_message_stores_answer_and_get_response_returns_it(tmp_path, monkeypatch):
+    backend = _Backend(ask_result=SimpleNamespace(answer="forty-two"))
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+    client.current_notebook_id = "nb1"
+
+    asyncio.run(client.send_message("What is the meaning?"))
+    # chat.ask was called with the current notebook id + message.
+    assert ("chat.ask", "nb1", "What is the meaning?") in backend.calls
+    # The stored answer is exactly the backend's .answer (mutation: dropping the
+    # store leaves the fallback string and fails this assertion).
+    assert asyncio.run(client.get_response()) == "forty-two"
+
+
+def test_get_response_empty_falls_back(tmp_path, monkeypatch):
+    backend = _Backend(ask_result=SimpleNamespace(answer=""))
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+    client.current_notebook_id = "nb1"
+
+    asyncio.run(client.send_message("q"))
+    assert asyncio.run(client.get_response()) == "No response content found"
+
+
+def test_get_response_before_any_send_is_fallback(tmp_path, monkeypatch):
+    backend = _Backend()
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+    # No send_message yet -> empty stored answer -> fallback.
+    assert asyncio.run(client.get_response()) == "No response content found"
+
+
+def test_send_message_without_notebook_raises(tmp_path, monkeypatch):
+    backend = _Backend()
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+    client.current_notebook_id = None
+
+    with pytest.raises(NavigationError, match="No notebook selected"):
+        asyncio.run(client.send_message("hi"))
+    # The chat backend was never asked because the notebook guard fired first.
+    assert not any(c[0] == "chat.ask" for c in backend.calls)
+
+
+def test_send_message_wraps_backend_error_as_chat_error(tmp_path, monkeypatch):
+    backend = _Backend(ask_error=RuntimeError("rpc 500"))
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+    client.current_notebook_id = "nb1"
+
+    with pytest.raises(ChatError, match="RPC chat failed"):
+        asyncio.run(client.send_message("hi"))
+
+
+def test_navigate_to_notebook_sets_current(tmp_path, monkeypatch):
+    backend = _Backend()
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    returned = asyncio.run(client.navigate_to_notebook("nb-xyz"))
+    assert returned == "nb-xyz"
+    assert client.current_notebook_id == "nb-xyz"
+
+
+# --------------------------------------------------------------------------- #
+# Notebook management
+# --------------------------------------------------------------------------- #
+def test_list_notebooks_maps_each(tmp_path, monkeypatch):
+    backend = _Backend(
+        notebooks=[
+            SimpleNamespace(id="a", title="Alpha", emoji="🅰", source_count=1),
+            SimpleNamespace(id="b", title="Beta", emoji="🅱", source_count=3),
+        ]
+    )
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    result = asyncio.run(client.list_notebooks())
+    assert result == [
+        {"id": "a", "title": "Alpha", "emoji": "🅰", "source_count": 1},
+        {"id": "b", "title": "Beta", "emoji": "🅱", "source_count": 3},
+    ]
+
+
+def test_create_notebook_forwards_title_and_maps(tmp_path, monkeypatch):
+    backend = _Backend()
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    result = asyncio.run(client.create_notebook("My Notebook"))
+    assert ("notebooks.create", "My Notebook") in backend.calls
+    assert result == {
+        "id": "nb-new",
+        "title": "My Notebook",
+        "emoji": "✨",
+        "source_count": 0,
+    }
+
+
+def test_rename_notebook_forwards_args_and_maps(tmp_path, monkeypatch):
+    backend = _Backend()
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    result = asyncio.run(client.rename_notebook("nb1", "New Name"))
+    assert ("notebooks.rename", "nb1", "New Name") in backend.calls
+    assert result["id"] == "nb1"
+    assert result["title"] == "New Name"
+
+
+def test_delete_notebook_forwards_id(tmp_path, monkeypatch):
+    backend = _Backend()
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    assert asyncio.run(client.delete_notebook("nb-del")) is None
+    assert ("notebooks.delete", "nb-del") in backend.calls
+
+
+def test_get_notebook_summary_coerces_to_str(tmp_path, monkeypatch):
+    backend = _Backend(summary=12345)  # non-string to prove str() coercion
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    result = asyncio.run(client.get_notebook_summary("nb1"))
+    assert ("notebooks.get_summary", "nb1") in backend.calls
+    assert result == "12345"
+    assert isinstance(result, str)
+
+
+# --------------------------------------------------------------------------- #
+# Source management
+# --------------------------------------------------------------------------- #
+def test_list_sources_forwards_id_and_maps(tmp_path, monkeypatch):
+    backend = _Backend(
+        sources=[
+            SimpleNamespace(id="s1", title="Src1", type="pdf", status="ready"),
+            SimpleNamespace(id="s2", title="Src2", source_type="url", status="busy"),
+        ]
+    )
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    result = asyncio.run(client.list_sources("nb1"))
+    assert ("sources.list", "nb1") in backend.calls
+    assert result[0] == {
+        "id": "s1",
+        "title": "Src1",
+        "type": "pdf",
+        "status": "ready",
+    }
+    # Second source has no ``type`` -> mapper falls back to source_type.
+    assert result[1]["type"] == "url"
+
+
+def test_add_source_url_forwards_and_maps(tmp_path, monkeypatch):
+    backend = _Backend()
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    result = asyncio.run(client.add_source_url("nb1", "https://example.com"))
+    assert ("sources.add_url", "nb1", "https://example.com") in backend.calls
+    assert result == {
+        "id": "src-url",
+        "title": "https://example.com",
+        "type": "url",
+        "status": "processing",
+    }
+
+
+def test_add_source_text_forwards_and_maps(tmp_path, monkeypatch):
+    backend = _Backend()
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    result = asyncio.run(client.add_source_text("nb1", "Title", "body text"))
+    assert ("sources.add_text", "nb1", "Title", "body text") in backend.calls
+    assert result["id"] == "src-text"
+    assert result["title"] == "Title"
+    assert result["type"] == "text"
+
+
+def test_delete_source_forwards_ids(tmp_path, monkeypatch):
+    backend = _Backend()
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    assert asyncio.run(client.delete_source("nb1", "src9")) is None
+    assert ("sources.delete", "nb1", "src9") in backend.calls
+
+
+# --------------------------------------------------------------------------- #
+# Management methods all require a started backend
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda c: c.list_notebooks(),
+        lambda c: c.create_notebook("t"),
+        lambda c: c.rename_notebook("n", "t"),
+        lambda c: c.delete_notebook("n"),
+        lambda c: c.get_notebook_summary("n"),
+        lambda c: c.list_sources("n"),
+        lambda c: c.add_source_url("n", "u"),
+        lambda c: c.add_source_text("n", "t", "x"),
+        lambda c: c.delete_source("n", "s"),
+    ],
+)
+def test_management_methods_require_started_backend(tmp_path, call):
+    cfg = make_config(tmp_path)
+    client = NotebookLMRPCClient(cfg)
+    with pytest.raises(ChatError, match="not started"):
+        asyncio.run(call(client))
+
+
+# --------------------------------------------------------------------------- #
+# close()
+# --------------------------------------------------------------------------- #
+def test_close_resets_state_and_calls_aexit(tmp_path, monkeypatch):
+    backend = _Backend()
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+    client._is_authenticated = True
+    cm = client._cm
+
+    asyncio.run(client.close())
+    assert cm.exited is True
+    assert client._backend is None
+    assert client._cm is None
+    assert client.is_authenticated is False
+
+
+def test_close_is_idempotent_without_backend(tmp_path):
+    cfg = make_config(tmp_path)
+    client = NotebookLMRPCClient(cfg)
+    # Never started -> close must be safe and a no-op.
+    asyncio.run(client.close())
+    asyncio.run(client.close())
+    assert client._backend is None
+    assert client._cm is None

--- a/tests/test_comprehensive_simple.py
+++ b/tests/test_comprehensive_simple.py
@@ -1,116 +1,111 @@
+"""Comprehensive, deterministic unit tests (no real browser).
+
+This suite was migrated off Selenium + undetected-chromedriver. The browser
+engine is now Patchright async Playwright, so:
+
+* ``selenium``/``undetected_chromedriver`` are uninstalled — nothing here may
+  import them;
+* the client is fully async (``start``/``authenticate``/``send_message``/
+  ``get_response``/``navigate_to_notebook``/``close``) and exposes the Playwright
+  ``Page`` via ``client.page`` (and the ``client.driver`` alias), whose URL is the
+  ``page.url`` property;
+* the removed Selenium internals (``_send_message_sync``, ``_authenticate_sync``,
+  ``WebDriverWait`` …) are re-expressed against the new async API using small
+  inline async fakes injected as ``client.page`` and monkeypatched helpers
+  (``_find_first``, ``_read_latest_response``, ``_is_thinking``).
+
+Only ``tests/test_integration.py`` is allowed to launch a real browser.
+"""
+
 import asyncio
 import json
 from types import MethodType, SimpleNamespace
 
 import pytest
 from click.testing import CliRunner
-from selenium.common.exceptions import TimeoutException
 
 import notebooklm_mcp.monitoring as monitoring
 import notebooklm_mcp.server as server_module
 from notebooklm_mcp import cli as cli_module
 from notebooklm_mcp.client import NotebookLMClient
-from notebooklm_mcp.config import ServerConfig
+from notebooklm_mcp.config import AuthConfig, ServerConfig
 from notebooklm_mcp.exceptions import ChatError, NavigationError, NotebookLMError
 
 
-class DummyElement:
-    def __init__(self, text: str = "", displayed: bool = True):
-        self.text = text
-        self._displayed = displayed
-        self.cleared = False
-        self.sent = []
+# --------------------------------------------------------------------------- #
+# Async Playwright fakes
+# --------------------------------------------------------------------------- #
+class FakeLocator:
+    """Minimal stand-in for a Playwright ``Locator``."""
 
-    def is_displayed(self) -> bool:
-        return self._displayed
+    def __init__(self, texts: list[str] | None = None, visible: bool = False):
+        self._texts = texts or []
+        self._visible = visible
+        self.clicked = False
+        self.filled: list[str] = []
+        self.pressed: list[str] = []
 
-    def clear(self) -> None:
-        self.cleared = True
+    @property
+    def first(self) -> "FakeLocator":
+        return self
 
-    def send_keys(self, value) -> None:
-        self.sent.append(value)
+    def nth(self, _index: int) -> "FakeLocator":
+        return self
 
+    async def count(self) -> int:
+        return len(self._texts)
 
-class DummyDriver:
-    def __init__(self):
-        self.current_url = "https://notebooklm.google.com/notebook/original"
-        self.calls: list[tuple[str, object]] = []
-        self.elements: dict[str, list[DummyElement]] = {}
-        self.chat_element = DummyElement()
+    async def inner_text(self) -> str:
+        return self._texts[-1] if self._texts else ""
 
-    def set_page_load_timeout(self, timeout: int) -> None:
-        self.calls.append(("timeout", timeout))
+    async def is_visible(self) -> bool:
+        return self._visible
 
-    def get(self, url: str) -> None:
-        self.current_url = url
-        self.calls.append(("get", url))
+    async def wait_for(self, **_kwargs) -> None:
+        return None
 
-    def find_elements(self, _by, selector: str):
-        return self.elements.get(selector, [])
+    async def click(self) -> None:
+        self.clicked = True
 
-    def quit(self) -> None:
-        self.calls.append(("quit", None))
+    async def fill(self, value: str) -> None:
+        self.filled.append(value)
 
-
-class DummyFastMCP:
-    def __init__(self, name: str):
-        self.name = name
-        self.tools: dict[str, callable] = {}
-        self.run_calls = []
-
-    def tool(self):
-        def decorator(func):
-            self.tools[func.__name__] = func
-            return func
-
-        return decorator
-
-    async def run_async(self, **kwargs):
-        self.run_calls.append(kwargs)
+    async def press(self, key: str) -> None:
+        self.pressed.append(key)
 
 
-class DummyClient:
-    def __init__(self, config: ServerConfig):
-        self.config = config
-        self.started = False
-        self.closed = False
-        self.sent_messages: list[str] = []
-        self._is_authenticated = True
-        self.navigated_to: list[str] = []
-        self.responses = ["response"]
+class FakePage:
+    """Minimal stand-in for a Playwright ``Page``."""
 
-    async def start(self):
-        self.started = True
+    def __init__(self, url: str = "https://notebooklm.google.com/notebook/abc"):
+        self._url = url
+        self.goto_calls: list[str] = []
+        self.default_timeout: int | None = None
+        self.locators: dict[str, FakeLocator] = {}
 
-    async def close(self):
-        self.closed = True
+    @property
+    def url(self) -> str:
+        return self._url
 
-    async def send_message(self, message: str):
-        self.sent_messages.append(message)
+    def set_default_timeout(self, timeout: int) -> None:
+        self.default_timeout = timeout
 
-    async def get_response(self) -> str:
-        return self.responses[-1]
+    async def goto(self, url: str, wait_until: str | None = None) -> None:
+        self._url = url
+        self.goto_calls.append(url)
 
-    async def navigate_to_notebook(self, notebook_id: str):
-        self.navigated_to.append(notebook_id)
-        self.config.default_notebook_id = notebook_id
+    def locator(self, selector: str) -> FakeLocator:
+        return self.locators.setdefault(selector, FakeLocator())
 
 
-class ImmediateLoop:
-    def __init__(self, loop: asyncio.AbstractEventLoop):
-        self._loop = loop
-
-    def run_in_executor(self, _executor, func, *args):
-        future = self._loop.create_future()
-        try:
-            result = func(*args)
-        except Exception as exc:  # pragma: no cover - exercised in tests
-            future.set_exception(exc)
-        else:
-            future.set_result(result)
-        return future
+def make_client(**config_kwargs) -> NotebookLMClient:
+    config = ServerConfig(**config_kwargs)
+    return NotebookLMClient(config)
 
 
+# --------------------------------------------------------------------------- #
+# CLI tests (engine-agnostic, still valid)
+# --------------------------------------------------------------------------- #
 def test_cli_creates_and_updates_config(tmp_path):
     notebook_id = "123e4567-e89b-12d3-a456-426614174000"
     config_path = tmp_path / "notebooklm-config.json"
@@ -196,279 +191,281 @@ def test_extract_notebook_id_variants():
         cli_module.extract_notebook_id("https://example.com")
 
 
-def test_client_authenticate_sets_flag(monkeypatch):
-    client = NotebookLMClient(ServerConfig(default_notebook_id="abc"))
-    driver = DummyDriver()
-    driver.current_url = "https://notebooklm.google.com/notebook/abc"
-    client.driver = driver
+# --------------------------------------------------------------------------- #
+# Client tests against the new async Patchright API
+# --------------------------------------------------------------------------- #
+def test_client_driver_alias_exposes_page():
+    """``client.driver`` is the back-compat alias monitoring reads."""
+    client = make_client()
+    page = FakePage()
+    client.page = page
+    assert client.driver is page
+    assert client.driver.url == page.url
+    assert client.is_authenticated is False
 
-    monkeypatch.setattr(
-        "notebooklm_mcp.client.WebDriverWait",
-        lambda driver, timeout: SimpleNamespace(until=lambda condition: True),
-    )
 
-    result = client._authenticate_sync()
+def test_client_authenticate_success(monkeypatch):
+    client = make_client(default_notebook_id="abc")
+    page = FakePage(url="https://notebooklm.google.com/notebook/abc")
+    client.page = page
+
+    async def fake_find_first(self, candidates, timeout):
+        return FakeLocator(visible=True)
+
+    monkeypatch.setattr(client, "_find_first", MethodType(fake_find_first, client))
+
+    result = asyncio.run(client.authenticate())
     assert result is True
     assert client._is_authenticated is True
-    assert any(call[0] == "get" for call in driver.calls)
+    # Authentication navigates to the target notebook URL.
+    assert page.goto_calls and page.goto_calls[-1].endswith("/notebook/abc")
 
 
-def test_client_send_message_sync(monkeypatch):
-    client = NotebookLMClient(ServerConfig(default_notebook_id="abc"))
-    driver = DummyDriver()
-    driver.current_url = "https://notebooklm.google.com/home"
-    client.driver = driver
-    client.current_notebook_id = "abc"
+def test_client_authenticate_detects_signed_out():
+    client = make_client(default_notebook_id="abc")
 
-    monkeypatch.setattr(
-        client,
-        "_navigate_to_notebook_sync",
-        MethodType(lambda self, notebook: driver.get(f"navigated/{notebook}"), client),
-    )
-    monkeypatch.setattr(
-        "notebooklm_mcp.client.WebDriverWait",
-        lambda driver, timeout: SimpleNamespace(
-            until=lambda condition: driver.chat_element
-        ),
-    )
+    class RedirectPage(FakePage):
+        async def goto(self, url, wait_until=None):
+            # Simulate Google bouncing us to the sign-in flow.
+            self._url = "https://accounts.google.com/signin"
+            self.goto_calls.append(url)
 
-    client._send_message_sync("hello world")
-    assert driver.chat_element.cleared is True
-    assert "hello world" in driver.chat_element.sent
+    client.page = RedirectPage()
+
+    result = asyncio.run(client.authenticate())
+    assert result is False
+    assert client._is_authenticated is False
 
 
-def test_client_start_fallback(monkeypatch):
-    client = NotebookLMClient(ServerConfig())
-    driver = DummyDriver()
-
-    monkeypatch.setattr("notebooklm_mcp.client.USE_UNDETECTED", False, raising=False)
-
-    def fake_start(self):
-        self.driver = driver
-
-    monkeypatch.setattr(
-        client,
-        "_start_regular_chrome",
-        MethodType(lambda self: fake_start(self), client),
-    )
-
-    client._start_browser()
-    assert client.driver is driver
-    assert ("timeout", client.config.timeout) in driver.calls
+def test_client_authenticate_requires_started_browser():
+    client = make_client(default_notebook_id="abc")
+    client.page = None
+    with pytest.raises(NotebookLMError):  # AuthenticationError subclasses this
+        asyncio.run(client.authenticate())
 
 
-def test_client_send_message_sync_errors(monkeypatch):
-    client = NotebookLMClient(ServerConfig(default_notebook_id="abc"))
-    driver = DummyDriver()
-    client.driver = driver
-    client.current_notebook_id = None
-
-    monkeypatch.setattr(
-        "notebooklm_mcp.client.WebDriverWait",
-        lambda driver, timeout: SimpleNamespace(
-            until=lambda condition: (_ for _ in ()).throw(TimeoutException())
-        ),
-    )
-
-    with pytest.raises(ChatError):
-        client._send_message_sync("hi")
-
-
-def test_client_send_message_async(monkeypatch):
-    client = NotebookLMClient(ServerConfig())
-    client.driver = object()
+def test_client_send_message_types_and_submits(monkeypatch):
+    client = make_client(default_notebook_id="abc")
+    page = FakePage(url="https://notebooklm.google.com/notebook/abc")
+    client.page = page
     client._is_authenticated = True
-    recorded = {}
 
-    monkeypatch.setattr(
-        client,
-        "_send_message_sync",
-        MethodType(lambda self, message: recorded.setdefault("msg", message), client),
-    )
+    composer = FakeLocator(visible=True)
 
-    async def run_test():
-        loop = asyncio.get_running_loop()
-        monkeypatch.setattr(
-            "notebooklm_mcp.client.asyncio.get_event_loop", lambda: ImmediateLoop(loop)
-        )
-        await client.send_message("payload")
+    async def fake_find_first(self, candidates, timeout):
+        return composer
 
-    asyncio.run(run_test())
-    assert recorded["msg"] == "payload"
+    monkeypatch.setattr(client, "_find_first", MethodType(fake_find_first, client))
+
+    asyncio.run(client.send_message("hello world"))
+    assert composer.clicked is True
+    assert composer.filled == ["hello world"]
+    assert composer.pressed == ["Enter"]
+
+
+def test_client_send_message_requires_auth():
+    client = make_client(default_notebook_id="abc")
+    client.page = FakePage()
+    client._is_authenticated = False
+    with pytest.raises(ChatError):
+        asyncio.run(client.send_message("hi"))
+
+
+def test_client_send_message_missing_composer(monkeypatch):
+    client = make_client(default_notebook_id="abc")
+    page = FakePage(url="https://notebooklm.google.com/notebook/abc")
+    client.page = page
+    client._is_authenticated = True
+
+    async def no_composer(self, candidates, timeout):
+        return None
+
+    monkeypatch.setattr(client, "_find_first", MethodType(no_composer, client))
+
+    with pytest.raises(ChatError, match="Could not find chat input"):
+        asyncio.run(client.send_message("hi"))
 
 
 def test_client_get_response_quick(monkeypatch):
-    client = NotebookLMClient(ServerConfig())
-    client.driver = object()
-    monkeypatch.setattr(
-        client,
-        "_get_current_response",
-        MethodType(lambda self: "response", client),
-    )
+    client = make_client()
+    client.page = FakePage()
 
-    async def run_test():
-        loop = asyncio.get_running_loop()
-        monkeypatch.setattr(
-            "notebooklm_mcp.client.asyncio.get_event_loop", lambda: ImmediateLoop(loop)
-        )
-        return await client.get_response(wait_for_completion=False)
+    async def fake_read(self):
+        return "the answer"
 
-    result = asyncio.run(run_test())
-    assert result == "response"
+    monkeypatch.setattr(client, "_read_latest_response", MethodType(fake_read, client))
+
+    result = asyncio.run(client.get_response(wait_for_completion=False))
+    assert result == "the answer"
 
 
-def test_check_streaming_indicators_detects_visible():
-    client = NotebookLMClient(ServerConfig())
-    driver = DummyDriver()
-    visible = DummyElement("", displayed=True)
-    driver.elements = {"[class*='loading']": [visible]}
-    client.driver = driver
+def test_client_get_response_empty_falls_back(monkeypatch):
+    client = make_client()
+    client.page = FakePage()
 
-    assert client._check_streaming_indicators() is True
-    visible._displayed = False
-    assert client._check_streaming_indicators() is False
+    async def fake_read(self):
+        return ""
 
+    monkeypatch.setattr(client, "_read_latest_response", MethodType(fake_read, client))
 
-def test_client_navigation_and_close(monkeypatch):
-    client = NotebookLMClient(ServerConfig())
-    driver = DummyDriver()
-    client.driver = driver
-
-    monkeypatch.setattr(
-        "notebooklm_mcp.client.WebDriverWait",
-        lambda driver, timeout: SimpleNamespace(until=lambda condition: True),
-    )
-
-    called = {}
-
-    def fake_quit():
-        called["quit"] = True
-
-    driver.quit = fake_quit
-
-    async def run_test():
-        loop = asyncio.get_running_loop()
-        monkeypatch.setattr(
-            "notebooklm_mcp.client.asyncio.get_event_loop", lambda: ImmediateLoop(loop)
-        )
-        url = await client.navigate_to_notebook("xyz")
-        assert url.endswith("/xyz")
-        await client.close()
-
-    asyncio.run(run_test())
-    assert called["quit"] is True
-    assert client.driver is None
+    result = asyncio.run(client.get_response(wait_for_completion=False))
+    assert result == "No response content found"
 
 
-def test_get_current_response_prefers_longest():
-    client = NotebookLMClient(ServerConfig())
-    driver = DummyDriver()
-    driver.elements = {
-        "[data-testid*='response']": [DummyElement("short")],
-        "[class*='response']:last-child": [
-            DummyElement("This is a substantially longer answer from NotebookLM")
-        ],
+def test_client_get_response_waits_until_idle(monkeypatch):
+    client = make_client(response_stability_checks=1)
+    client.page = FakePage()
+    reads = iter(["partial", "final", "final", "final"])
+
+    async def fake_read(self):
+        return next(reads, "final")
+
+    async def not_thinking(self):
+        return False
+
+    monkeypatch.setattr(client, "_read_latest_response", MethodType(fake_read, client))
+    monkeypatch.setattr(client, "_is_thinking", MethodType(not_thinking, client))
+
+    async def instant_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr("notebooklm_mcp.client.asyncio.sleep", instant_sleep)
+
+    result = asyncio.run(client.get_response(wait_for_completion=True, max_wait=5))
+    assert result == "final"
+
+
+def test_client_get_response_requires_browser():
+    client = make_client()
+    client.page = None
+    with pytest.raises(ChatError):
+        asyncio.run(client.get_response())
+
+
+def test_client_read_latest_response_prefers_populated_selector():
+    client = make_client()
+    page = FakePage()
+    # First selector empty, second has text — client should return the text.
+    page.locators = {
+        ".to-user-container .message-text-content": FakeLocator(texts=[]),
+        "chat-message .to-user-container .message-text-content": FakeLocator(
+            texts=["This is a substantially longer answer from NotebookLM"]
+        ),
     }
-    client.driver = driver
+    client.page = page
 
-    result = client._get_current_response()
+    result = asyncio.run(client._read_latest_response())
     assert "substantially longer" in result
 
 
-def test_get_current_response_fallback_text():
-    client = NotebookLMClient(ServerConfig())
+def test_client_is_thinking_detects_visible_indicator():
+    client = make_client()
+    page = FakePage()
+    page.locators = {"div.thinking-message": FakeLocator(visible=True)}
+    client.page = page
 
-    class FallbackDriver(DummyDriver):
-        def __init__(self):
-            super().__init__()
-            self.elements = {}
+    assert asyncio.run(client._is_thinking()) is True
 
-        def find_elements(self, _by, selector):
-            if selector == "p, div, span":
-                return [
-                    DummyElement("Ask about something"),
-                    DummyElement(
-                        "This is a comprehensive explanation that should be used as fallback"
-                    ),
-                ]
-            return []
-
-    client.driver = FallbackDriver()
-    result = client._get_current_response()
-    assert "comprehensive explanation" in result
+    page.locators["div.thinking-message"]._visible = False
+    for selector in ("div.thinking-message", ".thinking-message"):
+        page.locators[selector] = FakeLocator(visible=False)
+    assert asyncio.run(client._is_thinking()) is False
 
 
-def test_clean_response_text_removes_artifacts():
-    client = NotebookLMClient(ServerConfig())
-    messy = "Question?\ncopy_all\nthumb_down\nHere is the answer you need."
-    cleaned = client._clean_response_text(messy)
-    assert cleaned.startswith("Here is the answer")
+def test_client_navigate_to_notebook_updates_state():
+    client = make_client()
+    page = FakePage()
+    client.page = page
 
-
-def test_wait_for_streaming_response(monkeypatch):
-    client = NotebookLMClient(ServerConfig(response_stability_checks=1))
-    client.driver = object()
-    responses = iter(["complete", "complete"])
-
-    monkeypatch.setattr(
-        client,
-        "_get_current_response",
-        MethodType(lambda self: next(responses), client),
-    )
-    monkeypatch.setattr(
-        client,
-        "_check_streaming_indicators",
-        MethodType(lambda self: False, client),
-    )
-    monkeypatch.setattr("notebooklm_mcp.client.time.sleep", lambda _: None)
-
-    result = client._wait_for_streaming_response(1)
-    assert result == "complete"
-
-
-def test_wait_for_streaming_response_timeout(monkeypatch):
-    client = NotebookLMClient(ServerConfig())
-    client.driver = object()
-    monkeypatch.setattr(
-        client,
-        "_get_current_response",
-        MethodType(lambda self: "", client),
-    )
-    monkeypatch.setattr("notebooklm_mcp.client.time.sleep", lambda _: None)
-
-    result = client._wait_for_streaming_response(0)
-    assert result == "Response timeout - no content retrieved"
-
-
-def test_navigate_to_notebook_sync_success(monkeypatch):
-    client = NotebookLMClient(ServerConfig(default_notebook_id="abc"))
-    driver = DummyDriver()
-    client.driver = driver
-
-    monkeypatch.setattr(
-        "notebooklm_mcp.client.WebDriverWait",
-        lambda driver, timeout: SimpleNamespace(until=lambda condition: True),
-    )
-
-    result = client._navigate_to_notebook_sync("xyz")
-    assert result.endswith("/xyz")
+    url = asyncio.run(client.navigate_to_notebook("xyz"))
+    assert url.endswith("/notebook/xyz")
     assert client.current_notebook_id == "xyz"
 
 
-def test_navigate_to_notebook_sync_timeout(monkeypatch):
-    client = NotebookLMClient(ServerConfig(default_notebook_id="abc"))
-    driver = DummyDriver()
-    client.driver = driver
-
-    def failing_wait(driver, timeout):
-        return SimpleNamespace(
-            until=lambda condition: (_ for _ in ()).throw(TimeoutException())
-        )
-
-    monkeypatch.setattr("notebooklm_mcp.client.WebDriverWait", failing_wait)
-
+def test_client_navigate_requires_started_browser():
+    client = make_client()
+    client.page = None
     with pytest.raises(NavigationError):
-        client._navigate_to_notebook_sync("xyz")
+        asyncio.run(client.navigate_to_notebook("xyz"))
+
+
+def test_client_close_is_idempotent():
+    client = make_client()
+    client.page = FakePage()
+    client.context = None
+    client._playwright = None
+    client._is_authenticated = True
+
+    asyncio.run(client.close())
+    assert client.page is None
+    assert client._is_authenticated is False
+
+    # Second close must not raise (idempotent).
+    asyncio.run(client.close())
+    assert client.page is None
+
+
+# --------------------------------------------------------------------------- #
+# Server tests (lazy init, async DummyClient)
+# --------------------------------------------------------------------------- #
+class DummyFastMCP:
+    def __init__(self, name: str):
+        self.name = name
+        self.tools: dict[str, callable] = {}
+        self.run_calls = []
+
+    def tool(self):
+        def decorator(func):
+            self.tools[func.__name__] = func
+            return func
+
+        return decorator
+
+    async def run_async(self, **kwargs):
+        self.run_calls.append(kwargs)
+
+
+# Unique sentinel so response assertions test real wiring (the server
+# surfacing the client's value) rather than echoing a generic "response".
+DUMMY_RESPONSE = "client-produced-answer-9d21"
+
+
+class DummyClient:
+    def __init__(self, config: ServerConfig):
+        self.config = config
+        self.started = False
+        self.closed = False
+        self.authenticated = False
+        self.sent_messages: list[str] = []
+        self._is_authenticated = True
+        self.navigated_to: list[str] = []
+        self.responses = [DUMMY_RESPONSE]
+        self.call_order: list[str] = []
+        self.get_response_calls = 0
+
+    async def start(self):
+        self.started = True
+
+    async def authenticate(self):
+        self.authenticated = True
+        return True
+
+    async def close(self):
+        self.closed = True
+
+    async def send_message(self, message: str):
+        self.sent_messages.append(message)
+        self.call_order.append("send")
+
+    async def get_response(self) -> str:
+        self.get_response_calls += 1
+        self.call_order.append("get")
+        return self.responses[-1]
+
+    async def navigate_to_notebook(self, notebook_id: str):
+        self.navigated_to.append(notebook_id)
+        self.config.default_notebook_id = notebook_id
+        self.call_order.append("navigate")
 
 
 @pytest.fixture(autouse=True)
@@ -485,7 +482,7 @@ def server(monkeypatch):
     instance.client = dummy
 
     async def noop(self):
-        return None
+        return self.client
 
     instance._ensure_client = MethodType(noop, instance)
     return instance, dummy
@@ -506,17 +503,58 @@ def test_server_chat_flow(server):
     response = asyncio.run(server_instance.app.tools["send_chat_message"](request))
     assert response["status"] == "completed"
     assert dummy.sent_messages == ["hi"]
+    # The server must surface the client's actual response (unique sentinel),
+    # proving it isn't returning a hardcoded string.
+    assert response["response"] == DUMMY_RESPONSE
+    assert dummy.call_order == ["send", "get"]
 
+    dummy.call_order.clear()
     chat_request = server_module.ChatRequest(message="hey", notebook_id="new")
     response = asyncio.run(
         server_instance.app.tools["chat_with_notebook"](chat_request)
     )
     assert response["notebook_id"] == "new"
     assert dummy.navigated_to == ["new"]
+    assert response["response"] == DUMMY_RESPONSE
+    # navigate must precede send which precedes read.
+    assert dummy.call_order == ["navigate", "send", "get"]
 
     nav_request = server_module.NavigateRequest(notebook_id="abc")
     result = asyncio.run(server_instance.app.tools["navigate_to_notebook"](nav_request))
     assert result["status"] == "success"
+    assert result["notebook_id"] == "abc"
+
+
+def test_server_response_tools_wire_client_value(server):
+    """get_chat_response and get_quick_response must both surface the client's
+    real response value and each delegate to client.get_response() once."""
+    server_instance, dummy = server
+
+    chat = asyncio.run(
+        server_instance.app.tools["get_chat_response"](
+            server_module.GetResponseRequest(timeout=1)
+        )
+    )
+    quick = asyncio.run(server_instance.app.tools["get_quick_response"]())
+
+    assert chat["response"] == DUMMY_RESPONSE
+    assert quick["response"] == DUMMY_RESPONSE
+    assert chat["status"] == "success"
+    assert quick["status"] == "success"
+    assert dummy.get_response_calls == 2
+
+
+def test_server_send_chat_no_wait_skips_get_response(server):
+    """wait_for_response=False must send the message but never read a reply."""
+    server_instance, dummy = server
+    request = server_module.SendMessageRequest(message="hi", wait_for_response=False)
+    response = asyncio.run(server_instance.app.tools["send_chat_message"](request))
+
+    assert response["status"] == "sent"
+    assert "response" not in response
+    assert dummy.sent_messages == ["hi"]
+    assert dummy.get_response_calls == 0
+    assert dummy.call_order == ["send"]
 
 
 def test_server_default_notebook_tools(server):
@@ -530,7 +568,45 @@ def test_server_default_notebook_tools(server):
     assert server_instance.config.default_notebook_id == "xyz"
 
 
-def test_server_start_and_stop(monkeypatch):
+def test_server_ensure_client_lazy_init(monkeypatch):
+    """First tool call triggers start()+authenticate() exactly once."""
+    monkeypatch.setattr(server_module, "NotebookLMClient", DummyClient)
+    # engine="patchright" routes _build_client through the injectable
+    # NotebookLMClient symbol (the DummyClient), not the RPC backend.
+    instance = server_module.NotebookLMFastMCP(
+        ServerConfig(default_notebook_id="abc", engine="patchright")
+    )
+
+    asyncio.run(instance._ensure_client())
+    first_client = instance.client
+    assert first_client.started is True
+    assert first_client.authenticated is True
+
+    asyncio.run(instance._ensure_client())
+    assert instance.client is first_client  # not recreated
+
+
+def test_server_ensure_client_error_resets(monkeypatch):
+    """A failed init raises NotebookLMError and clears the client for retry."""
+
+    class FailingClient(DummyClient):
+        async def start(self):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(server_module, "NotebookLMClient", FailingClient)
+    # engine="patchright" so the injectable FailingClient is built and its
+    # start() raises deterministically (no RPC/browser bootstrap).
+    instance = server_module.NotebookLMFastMCP(
+        ServerConfig(default_notebook_id="abc", engine="patchright")
+    )
+
+    with pytest.raises(NotebookLMError, match="Client initialization failed"):
+        asyncio.run(instance._ensure_client())
+    assert instance.client is None
+
+
+def test_server_start_binds_transport_without_browser(monkeypatch):
+    """start() is lazy: it binds the transport and never touches the browser."""
     monkeypatch.setattr(server_module, "NotebookLMClient", DummyClient)
     instance = server_module.NotebookLMFastMCP(ServerConfig(default_notebook_id="abc"))
 
@@ -540,21 +616,30 @@ def test_server_start_and_stop(monkeypatch):
         "host": "0.0.0.0",
         "port": 9000,
     }
+    # No tool was called, so the browser client was never constructed.
+    assert instance.client is None
 
-    asyncio.run(instance.stop())
-    assert instance.client.closed is True
+    asyncio.run(instance.stop())  # nothing to close, must not raise
 
 
-def test_server_start_error(monkeypatch):
-    class ExplodingClient(DummyClient):
-        async def start(self):
-            raise RuntimeError("boom")
-
-    monkeypatch.setattr(server_module, "NotebookLMClient", ExplodingClient)
+def test_server_start_transport_error(monkeypatch):
+    """The start() error path fires when the transport layer itself fails."""
+    monkeypatch.setattr(server_module, "NotebookLMClient", DummyClient)
     instance = server_module.NotebookLMFastMCP(ServerConfig(default_notebook_id="abc"))
+
+    async def boom(**_kwargs):
+        raise RuntimeError("transport down")
+
+    instance.app.run_async = boom
 
     with pytest.raises(NotebookLMError, match="Server startup failed"):
         asyncio.run(instance.start())
+
+
+def test_server_stop_closes_client(server):
+    server_instance, dummy = server
+    asyncio.run(server_instance.stop())
+    assert dummy.closed is True
 
 
 def test_server_tool_error_paths(monkeypatch, server):
@@ -574,6 +659,9 @@ def test_server_tool_error_paths(monkeypatch, server):
         )
 
 
+# --------------------------------------------------------------------------- #
+# Monitoring tests
+# --------------------------------------------------------------------------- #
 class DummyPsutil:
     def __init__(self, memory_percent=10.0, cpu_percent=20.0):
         self._memory_percent = memory_percent
@@ -685,10 +773,10 @@ def test_health_checker_reports_status(monkeypatch):
     dummy_psutil = DummyPsutil(memory_percent=40.0, cpu_percent=30.0)
     monkeypatch.setattr(monitoring, "psutil", dummy_psutil)
 
+    # Patchright client surfaces the URL via ``driver.url`` (page.url), not the
+    # Selenium ``current_url``.
     client = SimpleNamespace(
-        driver=SimpleNamespace(
-            current_url="https://notebooklm.google.com/notebook/123"
-        ),
+        driver=SimpleNamespace(url="https://notebooklm.google.com/notebook/123"),
         _is_authenticated=True,
     )
 
@@ -854,3 +942,11 @@ def test_health_checker_handles_exception(monkeypatch):
     result = asyncio.run(checker.check_health())
     assert result.healthy is False
     assert result.browser_status == "error"
+
+
+# Keep AuthConfig referenced so config import is meaningful even if the smoke
+# integration tier (which uses it) is skipped in headless CI.
+def test_auth_config_defaults():
+    cfg = ServerConfig(auth=AuthConfig(profile_dir="/tmp/x"))
+    assert cfg.auth.profile_dir == "/tmp/x"
+    assert cfg.auth.use_persistent_session is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -124,6 +124,185 @@ def test_setup_and_export_profile(tmp_path, monkeypatch):
     assert (exported / "cache").read_text() == "cache-data"
 
 
+def test_setup_profile_creates_new_directory_when_no_import(tmp_path):
+    """Without import_profile_from, setup_profile must create the profile dir
+    (covers the create-new-directory branch, config.py 170-172)."""
+    profile_dir = tmp_path / "fresh" / "profile"
+    config = ServerConfig(
+        auth=AuthConfig(profile_dir=str(profile_dir), import_profile_from=None)
+    )
+
+    assert not profile_dir.exists()
+    config.setup_profile()
+    assert profile_dir.is_dir()
+
+    # Idempotent: a second call with an existing dir must not raise and must
+    # leave the directory intact.
+    config.setup_profile()
+    assert profile_dir.is_dir()
+
+
+def test_setup_profile_import_replaces_existing_destination(tmp_path):
+    """When the destination already exists, import must wipe it first and copy
+    the source over it (covers the rmtree-on-import branch, config.py 164)."""
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "new.txt").write_text("new")
+
+    dest = tmp_path / "dest"
+    dest.mkdir()
+    # Stale file that must NOT survive the re-import.
+    (dest / "stale.txt").write_text("stale")
+
+    config = ServerConfig(
+        auth=AuthConfig(profile_dir=str(dest), import_profile_from=str(source))
+    )
+    config.setup_profile()
+
+    assert (dest / "new.txt").read_text() == "new"
+    assert not (dest / "stale.txt").exists()
+
+
+def test_setup_profile_blank_import_path_treated_as_none(tmp_path):
+    """A whitespace-only import path must be ignored (not treated as a real
+    path), so setup_profile falls through to the create-directory branch."""
+    profile_dir = tmp_path / "blank" / "profile"
+    config = ServerConfig(
+        auth=AuthConfig(profile_dir=str(profile_dir), import_profile_from="   ")
+    )
+
+    config.setup_profile()
+    assert profile_dir.is_dir()
+
+
+def test_export_profile_no_target_is_noop(tmp_path):
+    """With export_profile_to unset, export_profile must return without doing
+    anything (covers the early-return branch, config.py 177)."""
+    source = tmp_path / "profile"
+    source.mkdir()
+    (source / "data.txt").write_text("x")
+
+    config = ServerConfig(
+        auth=AuthConfig(profile_dir=str(source), export_profile_to=None)
+    )
+
+    # Must not raise and must not create anything.
+    config.export_profile()
+    assert list(tmp_path.iterdir()) == [source]
+
+
+def test_export_profile_overwrites_existing_target(tmp_path):
+    """When the export target already exists it must be wiped and replaced
+    (covers the rmtree-on-export branch, config.py 188)."""
+    source = tmp_path / "profile"
+    source.mkdir()
+    (source / "current.txt").write_text("current")
+
+    export_target = tmp_path / "exported"
+    export_target.mkdir()
+    (export_target / "old.txt").write_text("old")
+
+    config = ServerConfig(
+        auth=AuthConfig(profile_dir=str(source), export_profile_to=str(export_target))
+    )
+    config.export_profile()
+
+    assert (export_target / "current.txt").read_text() == "current"
+    # The pre-existing content was removed before the copy.
+    assert not (export_target / "old.txt").exists()
+
+
+def test_chrome_channel_and_binary_round_trip(tmp_path):
+    """The chrome_channel / chrome_binary fields must survive a full
+    to_dict -> from_dict -> save_to_file -> from_file round trip."""
+    profile_dir = tmp_path / "profiles" / "p"
+    profile_dir.parent.mkdir()
+
+    config = ServerConfig(
+        chrome_binary="/opt/google/chrome/chrome",
+        auth=AuthConfig(
+            profile_dir=str(profile_dir),
+            chrome_channel="chromium",
+        ),
+    )
+
+    # to_dict surfaces both fields.
+    data = config.to_dict()
+    assert data["chrome_binary"] == "/opt/google/chrome/chrome"
+    assert data["auth"]["chrome_channel"] == "chromium"
+
+    # from_dict restores them.
+    restored = ServerConfig.from_dict(json.loads(json.dumps(data)))
+    assert restored.chrome_binary == "/opt/google/chrome/chrome"
+    assert restored.auth.chrome_channel == "chromium"
+
+    # And they survive a file save/load round trip.
+    path = tmp_path / "cfg.json"
+    config.save_to_file(str(path))
+    from_file = ServerConfig.from_file(str(path))
+    assert from_file.chrome_binary == "/opt/google/chrome/chrome"
+    assert from_file.auth.chrome_channel == "chromium"
+
+
+def test_chrome_channel_defaults_to_chrome():
+    """The default channel is 'chrome' and chrome_binary defaults to None."""
+    config = ServerConfig()
+    assert config.auth.chrome_channel == "chrome"
+    assert config.chrome_binary is None
+
+
+def test_engine_defaults_to_rpc():
+    """The RPC engine is the new default and storage_state_path defaults None."""
+    config = ServerConfig()
+    assert config.engine == "rpc"
+    assert config.auth.storage_state_path is None
+
+
+def test_engine_and_storage_state_round_trip(tmp_path):
+    """``engine`` and ``auth.storage_state_path`` must survive a full
+    to_dict -> from_dict -> save_to_file -> from_file round trip."""
+    profile_dir = tmp_path / "profiles" / "p"
+    profile_dir.parent.mkdir()
+
+    config = ServerConfig(
+        engine="patchright",
+        auth=AuthConfig(
+            profile_dir=str(profile_dir),
+            storage_state_path="/tmp/state/storage_state.json",
+        ),
+    )
+
+    # to_dict surfaces both new fields.
+    data = config.to_dict()
+    assert data["engine"] == "patchright"
+    assert data["auth"]["storage_state_path"] == "/tmp/state/storage_state.json"
+
+    # from_dict restores them (through a JSON round trip to catch serialization
+    # surprises).
+    restored = ServerConfig.from_dict(json.loads(json.dumps(data)))
+    assert restored.engine == "patchright"
+    assert restored.auth.storage_state_path == "/tmp/state/storage_state.json"
+
+    # And they survive a file save/load round trip.
+    path = tmp_path / "cfg.json"
+    config.save_to_file(str(path))
+    from_file = ServerConfig.from_file(str(path))
+    assert from_file.engine == "patchright"
+    assert from_file.auth.storage_state_path == "/tmp/state/storage_state.json"
+
+
+def test_engine_round_trips_default_rpc(tmp_path):
+    """The default engine='rpc' / storage_state_path=None also round-trips
+    (so a default config written to disk loads back identically)."""
+    config = ServerConfig(default_notebook_id="abc")
+    path = tmp_path / "default_cfg.json"
+    config.save_to_file(str(path))
+
+    from_file = ServerConfig.from_file(str(path))
+    assert from_file.engine == "rpc"
+    assert from_file.auth.storage_state_path is None
+
+
 def test_export_profile_missing_source(tmp_path):
     config = ServerConfig(
         auth=AuthConfig(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,106 @@
+"""Real-browser integration tier (Patchright + Chrome).
+
+These tests actually launch a browser, so they are the only ones that catch a
+genuine launch/auth regression that the fully-mocked unit suites cannot. They
+are gated by two markers (see ``tests/conftest.py``):
+
+* ``browser``      — skipped when no ``DISPLAY`` (and not ``GITHUB_ACTIONS``);
+* ``integration``  — skipped when ``SKIP_INTEGRATION_TESTS`` is set.
+
+So a default local ``uv run pytest`` (no DISPLAY) skips them and stays fast and
+green, while CI (which sets ``GITHUB_ACTIONS`` and installs Chrome) runs them.
+When they DO run, they must fail loudly if the browser can't launch — that is
+the entire point of this tier.
+
+They are intentionally written without ``pytest-asyncio`` auto-mode: each test
+drives the async client through ``asyncio.run`` so the gating/marking behaves
+identically regardless of the project's asyncio config.
+"""
+
+import asyncio
+
+import pytest
+
+from notebooklm_mcp.client import NotebookLMClient
+from notebooklm_mcp.config import AuthConfig, ServerConfig
+
+# A generous ceiling: launching real Chrome + first navigation can be slow on
+# a cold CI runner. If we blow past this, something is genuinely wrong.
+LAUNCH_TIMEOUT_SECONDS = 120
+
+pytestmark = [pytest.mark.browser, pytest.mark.integration]
+
+
+def _fresh_config(tmp_path) -> ServerConfig:
+    """A headless config pointed at an empty, throwaway profile dir.
+
+    A fresh profile guarantees a signed-out session, which is exactly what we
+    want to assert against deterministically.
+    """
+    profile_dir = tmp_path / "chrome_profile_integration"
+    return ServerConfig(
+        headless=True,
+        default_notebook_id=None,
+        auth=AuthConfig(
+            profile_dir=str(profile_dir),
+            use_persistent_session=True,
+        ),
+    )
+
+
+def test_real_browser_smoke(tmp_path):
+    """Launch a real browser, authenticate (expect signed-out), close twice.
+
+    This is the one test that exercises the actual Patchright+Chrome launch
+    path end to end. A fresh profile is not logged in, so ``authenticate()``
+    must return ``False`` — but it must return a *bool*, not raise.
+    """
+    config = _fresh_config(tmp_path)
+
+    async def scenario():
+        client = NotebookLMClient(config)
+        try:
+            await asyncio.wait_for(client.start(), timeout=LAUNCH_TIMEOUT_SECONDS)
+            # A live Playwright page must exist after start().
+            assert client.page is not None
+            assert client.driver is client.page
+
+            authed = await asyncio.wait_for(
+                client.authenticate(), timeout=LAUNCH_TIMEOUT_SECONDS
+            )
+            assert isinstance(authed, bool)
+            # Fresh profile => not logged in.
+            assert authed is False
+            assert client.is_authenticated is False
+        finally:
+            # Always release the browser, and prove close() is idempotent.
+            await client.close()
+            assert client.page is None
+            await client.close()  # second call must not raise
+            assert client.page is None
+
+    asyncio.run(scenario())
+
+
+def test_real_authenticate_detects_signed_out(tmp_path):
+    """A fresh profile must be detected as signed out via the real redirect.
+
+    NotebookLM bounces a logged-out user to ``accounts.google.com``; the client
+    keys off that to report ``authenticate() is False``. This asserts the real
+    redirect path, complementing the mocked unit-level version.
+    """
+    config = _fresh_config(tmp_path)
+
+    async def scenario():
+        client = NotebookLMClient(config)
+        try:
+            await asyncio.wait_for(client.start(), timeout=LAUNCH_TIMEOUT_SECONDS)
+            authed = await asyncio.wait_for(
+                client.authenticate(), timeout=LAUNCH_TIMEOUT_SECONDS
+            )
+            assert authed is False
+            assert client.is_authenticated is False
+        finally:
+            await client.close()
+
+    asyncio.run(scenario())

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -30,6 +30,26 @@ def test_metrics_collector_record_request():
     assert metrics["average_response_time"] > 0
 
 
+def test_metrics_collector_trims_request_times_ring_buffer():
+    """The rolling average keeps only the last 100 samples: recording more
+    than 100 requests must trim the oldest (covers the pop(0) branch)."""
+    collector = monitoring.MetricsCollector()
+    # 100 fast requests then 5 slow ones: if the buffer were unbounded the
+    # average would be dragged down by the early fast samples.
+    for _ in range(100):
+        collector.record_request(True, 0.0)
+    for _ in range(5):
+        collector.record_request(True, 10.0)
+
+    # Buffer is capped at 100 entries.
+    assert len(collector._request_times) == 100
+    # The oldest 0.0 samples were popped, so the average reflects the recent
+    # window (a mix of trailing 0.0s and the five 10.0s), strictly > 0.
+    metrics = collector.get_metrics()
+    assert metrics["requests_total"] == 105
+    assert metrics["average_response_time"] > 0
+
+
 def test_metrics_collector_update_active_sessions():
     collector = monitoring.MetricsCollector()
     collector.update_active_sessions(3)
@@ -120,10 +140,10 @@ async def test_health_checker_reports_status(monkeypatch):
     dummy_psutil = DummyPsutil(memory_percent=40.0, cpu_percent=30.0)
     monkeypatch.setattr(monitoring, "psutil", dummy_psutil)
 
+    # The Patchright client exposes the page URL via the ``url`` attribute
+    # (``page.url``), not Selenium's ``current_url``.
     client = SimpleNamespace(
-        driver=SimpleNamespace(
-            current_url="https://notebooklm.google.com/notebook/123"
-        ),
+        driver=SimpleNamespace(url="https://notebooklm.google.com/notebook/123"),
         _is_authenticated=True,
     )
 
@@ -134,6 +154,69 @@ async def test_health_checker_reports_status(monkeypatch):
     assert result.healthy is True
     assert result.browser_status == "healthy"
     assert result.authentication_status == "authenticated"
+
+
+@pytest.mark.asyncio
+async def test_health_checker_browser_unhealthy_when_url_raises(monkeypatch):
+    """If reading ``driver.url`` raises, the browser is reported as unhealthy
+    (with a truncated error) and overall health is False even on a clean box."""
+    dummy_psutil = DummyPsutil(memory_percent=10.0, cpu_percent=5.0)
+    monkeypatch.setattr(monitoring, "psutil", dummy_psutil)
+
+    class BrokenDriver:
+        @property
+        def url(self):
+            raise RuntimeError("page crashed: navigation timeout exceeded")
+
+    client = SimpleNamespace(driver=BrokenDriver(), _is_authenticated=True)
+    checker = monitoring.HealthChecker(client)
+    monitoring.metrics_collector.start_time = asyncio.get_event_loop().time()
+
+    result = await checker.check_health()
+
+    assert result.browser_status.startswith("unhealthy:")
+    assert "page crashed" in result.browser_status
+    # The error message is truncated to 50 chars by the source.
+    assert len(result.browser_status) <= len("unhealthy: ") + 50
+    # A dead browser means overall health is False even with low mem/cpu.
+    assert result.healthy is False
+    # Auth status is still computed independently.
+    assert result.authentication_status == "authenticated"
+
+
+@pytest.mark.asyncio
+async def test_health_checker_unhealthy_when_resources_exhausted(monkeypatch):
+    """Even with a healthy browser, high memory/CPU must flip overall health
+    to False (the >=90% threshold branch)."""
+    monkeypatch.setattr(
+        monitoring, "psutil", DummyPsutil(memory_percent=95.0, cpu_percent=10.0)
+    )
+    client = SimpleNamespace(
+        driver=SimpleNamespace(url="https://notebooklm.google.com/notebook/1"),
+        _is_authenticated=True,
+    )
+    checker = monitoring.HealthChecker(client)
+    monitoring.metrics_collector.start_time = asyncio.get_event_loop().time()
+
+    result = await checker.check_health()
+    assert result.browser_status == "healthy"
+    # Browser is fine but memory is over threshold -> not healthy overall.
+    assert result.healthy is False
+
+
+@pytest.mark.asyncio
+async def test_health_checker_no_client_is_unknown(monkeypatch):
+    """With no client at all, browser/auth are 'unknown' and health is False."""
+    monkeypatch.setattr(
+        monitoring, "psutil", DummyPsutil(memory_percent=10.0, cpu_percent=5.0)
+    )
+    checker = monitoring.HealthChecker(None)
+    monitoring.metrics_collector.start_time = asyncio.get_event_loop().time()
+
+    result = await checker.check_health()
+    assert result.browser_status == "unknown"
+    assert result.authentication_status == "unknown"
+    assert result.healthy is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -26,30 +26,50 @@ class DummyFastMCP:
         self.run_calls.append(kwargs)
 
 
+# A distinctive sentinel that the production code can only surface by actually
+# wiring the client's return value through. Asserting on this (rather than a
+# generic "response") turns the response-field checks from tautologies into
+# real wiring assertions: a mutation that hardcodes any other string is caught.
+DUMMY_RESPONSE = "client-produced-answer-7f3a"
+
+
 class DummyClient:
     def __init__(self, config):
         self.config = config
         self.started = False
         self.closed = False
+        self.authenticated = False
         self.sent_messages = []
         self._is_authenticated = True
         self.navigated_to = []
+        # Ordered log of orchestration calls so tests can assert the server
+        # drives the client in the right sequence (navigate -> send -> read).
+        self.call_order: list[str] = []
+        self.get_response_calls = 0
 
     async def start(self):
         self.started = True
+
+    async def authenticate(self):
+        self.authenticated = True
+        return True
 
     async def close(self):
         self.closed = True
 
     async def send_message(self, message):
         self.sent_messages.append(message)
+        self.call_order.append("send")
 
     async def get_response(self):
-        return "response"
+        self.get_response_calls += 1
+        self.call_order.append("get")
+        return DUMMY_RESPONSE
 
     async def navigate_to_notebook(self, notebook_id):
         self.config.default_notebook_id = notebook_id
         self.navigated_to.append(notebook_id)
+        self.call_order.append("navigate")
 
 
 @pytest.fixture(autouse=True)
@@ -86,13 +106,18 @@ async def test_ensure_client_initializes_once(monkeypatch):
             created.append(self)
 
     monkeypatch.setattr(server_module, "NotebookLMClient", TrackingClient)
-    server = server_module.NotebookLMFastMCP(ServerConfig(default_notebook_id="abc"))
+    # engine="patchright" routes _build_client through the injectable
+    # NotebookLMClient symbol (the TrackingClient) instead of the RPC backend.
+    server = server_module.NotebookLMFastMCP(
+        ServerConfig(default_notebook_id="abc", engine="patchright")
+    )
 
     await server._ensure_client()
     await server._ensure_client()
 
     assert len(created) == 1
     assert created[0].started is True
+    assert created[0].authenticated is True
 
 
 @pytest.mark.asyncio
@@ -102,10 +127,17 @@ async def test_ensure_client_errors_propagate(monkeypatch):
             raise RuntimeError("boom")
 
     monkeypatch.setattr(server_module, "NotebookLMClient", FailingClient)
-    server = server_module.NotebookLMFastMCP(ServerConfig(default_notebook_id="abc"))
+    # engine="patchright" so the injectable FailingClient is built (and its
+    # start() raises) without touching the RPC/browser bootstrap path.
+    server = server_module.NotebookLMFastMCP(
+        ServerConfig(default_notebook_id="abc", engine="patchright")
+    )
 
     with pytest.raises(NotebookLMError, match="Client initialization failed"):
         await server._ensure_client()
+
+    # On failure the client must be reset so the next call retries cleanly.
+    assert server.client is None
 
 
 @pytest.mark.asyncio
@@ -122,13 +154,39 @@ async def test_start_uses_transport(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_start_handles_errors(monkeypatch):
+async def test_start_does_not_init_browser_eagerly(monkeypatch):
+    """Lazy init: a broken browser client must NOT stop the transport binding.
+
+    ``start()`` no longer calls ``_ensure_client`` — the browser is created on
+    the first tool call — so even a client whose ``start()`` explodes leaves the
+    transport free to bind.
+    """
+
     class ExplodingClient(DummyClient):
-        async def start(self):  # pragma: no cover - error branch
+        async def start(self):  # pragma: no cover - must never be called by start()
             raise RuntimeError("fail")
 
     monkeypatch.setattr(server_module, "NotebookLMClient", ExplodingClient)
     server = server_module.NotebookLMFastMCP(ServerConfig(default_notebook_id="abc"))
+
+    # Should NOT raise: the transport binds without touching the browser.
+    await server.start()
+
+    assert server.app.run_calls[-1] == {"transport": "stdio"}
+    # The client was never constructed because no tool was invoked.
+    assert server.client is None
+
+
+@pytest.mark.asyncio
+async def test_start_handles_transport_errors(monkeypatch):
+    """The ``start()`` error path now fires when the transport itself fails."""
+    monkeypatch.setattr(server_module, "NotebookLMClient", DummyClient)
+    server = server_module.NotebookLMFastMCP(ServerConfig(default_notebook_id="abc"))
+
+    async def boom(**_kwargs):
+        raise RuntimeError("transport down")
+
+    server.app.run_async = boom
 
     with pytest.raises(NotebookLMError, match="Server startup failed"):
         await server.start()
@@ -137,7 +195,11 @@ async def test_start_handles_errors(monkeypatch):
 @pytest.mark.asyncio
 async def test_stop_closes_client(monkeypatch):
     monkeypatch.setattr(server_module, "NotebookLMClient", DummyClient)
-    server = server_module.NotebookLMFastMCP(ServerConfig(default_notebook_id="abc"))
+    # engine="patchright" so the real _ensure_client builds the injectable
+    # DummyClient (not the RPC backend).
+    server = server_module.NotebookLMFastMCP(
+        ServerConfig(default_notebook_id="abc", engine="patchright")
+    )
     await server._ensure_client()
 
     await server.stop()
@@ -149,13 +211,28 @@ async def test_healthcheck_tool_reports_status(monkeypatch):
     monkeypatch.setattr(server_module, "NotebookLMClient", DummyClient)
     server = server_module.NotebookLMFastMCP(ServerConfig(default_notebook_id="abc"))
 
+    # No client -> unhealthy, not authenticated.
     result = await server.app.tools["healthcheck"]()
     assert result["status"] == "unhealthy"
+    assert result["authenticated"] is False
 
+    # Authenticated client -> healthy, and the payload reflects real config.
     dummy = DummyClient(server.config)
+    dummy._is_authenticated = True
     server.client = dummy
     result = await server.app.tools["healthcheck"]()
     assert result["status"] == "healthy"
+    assert result["authenticated"] is True
+    assert result["notebook_id"] == "abc"
+    # headless defaults to False -> gui mode (proves config.headless is read).
+    assert result["mode"] == "gui"
+
+    # Client present but NOT authenticated -> needs_auth (distinct from both
+    # the no-client and the healthy paths).
+    dummy._is_authenticated = False
+    result = await server.app.tools["healthcheck"]()
+    assert result["status"] == "needs_auth"
+    assert result["authenticated"] is False
 
 
 @pytest.mark.asyncio
@@ -166,7 +243,7 @@ async def test_send_chat_message_tool(monkeypatch):
     server.client = dummy
 
     async def fake_ensure(self):
-        return None
+        return self.client
 
     server._ensure_client = MethodType(fake_ensure, server)
     request = server_module.SendMessageRequest(message="hi", wait_for_response=True)
@@ -174,6 +251,14 @@ async def test_send_chat_message_tool(monkeypatch):
 
     assert dummy.sent_messages == ["hi"]
     assert response["status"] == "completed"
+    # The echoed message must be exactly what we sent (not a fixed string).
+    assert response["message"] == "hi"
+    # wait_for_response=True must surface the client's real response via
+    # get_response(); assert on the unique sentinel and the call ordering
+    # (send happens before get).
+    assert response["response"] == DUMMY_RESPONSE
+    assert dummy.get_response_calls == 1
+    assert dummy.call_order == ["send", "get"]
 
 
 @pytest.mark.asyncio
@@ -184,7 +269,7 @@ async def test_send_chat_message_tool_no_wait(monkeypatch):
     server.client = dummy
 
     async def fake_ensure(self):
-        return None
+        return self.client
 
     server._ensure_client = MethodType(fake_ensure, server)
     request = server_module.SendMessageRequest(message="hi", wait_for_response=False)
@@ -192,6 +277,11 @@ async def test_send_chat_message_tool_no_wait(monkeypatch):
 
     assert response["status"] == "sent"
     assert "response" not in response
+    # wait_for_response=False must NOT call get_response: the message is sent
+    # but the server returns without reading a reply.
+    assert dummy.sent_messages == ["hi"]
+    assert dummy.get_response_calls == 0
+    assert dummy.call_order == ["send"]
 
 
 @pytest.mark.asyncio
@@ -205,7 +295,7 @@ async def test_send_chat_message_tool_error(monkeypatch):
     server.client = FailingClient(server.config)
 
     async def fake_ensure(self):
-        return None
+        return self.client
 
     server._ensure_client = MethodType(fake_ensure, server)
     request = server_module.SendMessageRequest(message="hi", wait_for_response=False)
@@ -222,7 +312,7 @@ async def test_chat_with_notebook_tool(monkeypatch):
     server.client = dummy
 
     async def fake_ensure(self):
-        return None
+        return self.client
 
     server._ensure_client = MethodType(fake_ensure, server)
     request = server_module.ChatRequest(message="hello", notebook_id="xyz")
@@ -231,6 +321,35 @@ async def test_chat_with_notebook_tool(monkeypatch):
     assert dummy.sent_messages == ["hello"]
     assert dummy.navigated_to == ["xyz"]
     assert response["notebook_id"] == "xyz"
+    # Full orchestration contract: when a notebook_id is given the server must
+    # navigate FIRST, then send, then read the response — in that exact order.
+    assert dummy.call_order == ["navigate", "send", "get"]
+    assert response["response"] == DUMMY_RESPONSE
+    assert response["message"] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_chat_with_notebook_no_navigation_when_id_absent(monkeypatch):
+    """When no notebook_id is supplied the server must skip navigation and
+    fall back to the configured default notebook id in its response."""
+    monkeypatch.setattr(server_module, "NotebookLMClient", DummyClient)
+    server = server_module.NotebookLMFastMCP(ServerConfig(default_notebook_id="abc"))
+    dummy = DummyClient(server.config)
+    server.client = dummy
+
+    async def fake_ensure(self):
+        return self.client
+
+    server._ensure_client = MethodType(fake_ensure, server)
+    request = server_module.ChatRequest(message="hello", notebook_id=None)
+    response = await server.app.tools["chat_with_notebook"](request)
+
+    # No navigation happened; only send + read.
+    assert dummy.navigated_to == []
+    assert dummy.call_order == ["send", "get"]
+    # The response falls back to the server's configured default notebook.
+    assert response["notebook_id"] == "abc"
+    assert response["response"] == DUMMY_RESPONSE
 
 
 @pytest.mark.asyncio
@@ -241,7 +360,7 @@ async def test_get_chat_response_and_quick_response(monkeypatch):
     server.client = dummy
 
     async def fake_ensure(self):
-        return None
+        return self.client
 
     server._ensure_client = MethodType(fake_ensure, server)
     request = server_module.GetResponseRequest(timeout=1)
@@ -249,8 +368,14 @@ async def test_get_chat_response_and_quick_response(monkeypatch):
     chat_result = await server.app.tools["get_chat_response"](request)
     quick_result = await server.app.tools["get_quick_response"]()
 
-    assert chat_result["response"] == "response"
-    assert quick_result["response"] == "response"
+    # Assert on the unique sentinel: this proves the server surfaces the
+    # client's actual return value (not a hardcoded "response" string) and
+    # that each tool delegated to client.get_response().
+    assert chat_result["response"] == DUMMY_RESPONSE
+    assert quick_result["response"] == DUMMY_RESPONSE
+    assert chat_result["status"] == "success"
+    assert quick_result["status"] == "success"
+    assert dummy.get_response_calls == 2
 
 
 @pytest.mark.asyncio
@@ -264,7 +389,7 @@ async def test_get_chat_response_error(monkeypatch):
     server.client = FailingClient(server.config)
 
     async def fake_ensure(self):
-        return None
+        return self.client
 
     server._ensure_client = MethodType(fake_ensure, server)
     request = server_module.GetResponseRequest(timeout=1)
@@ -284,7 +409,7 @@ async def test_quick_response_error(monkeypatch):
     server.client = FailingClient(server.config)
 
     async def fake_ensure(self):
-        return None
+        return self.client
 
     server._ensure_client = MethodType(fake_ensure, server)
 
@@ -300,7 +425,7 @@ async def test_get_and_set_default_notebook_tools(monkeypatch):
     server.client = dummy
 
     async def fake_ensure(self):
-        return None
+        return self.client
 
     server._ensure_client = MethodType(fake_ensure, server)
 
@@ -310,7 +435,33 @@ async def test_get_and_set_default_notebook_tools(monkeypatch):
     request = server_module.SetNotebookRequest(notebook_id="new-id")
     set_result = await server.app.tools["set_default_notebook"](request)
     assert set_result["new_notebook_id"] == "new-id"
+    # The old id must be captured BEFORE the swap, proving the server records
+    # the transition rather than echoing the new value twice.
+    assert set_result["old_notebook_id"] == "abc"
     assert server.config.default_notebook_id == "new-id"
+
+
+@pytest.mark.asyncio
+async def test_chat_with_notebook_tool_error_wraps_exception(monkeypatch):
+    """A failure inside chat_with_notebook must be wrapped as NotebookLMError
+    (covers the error path, server.py 205-207)."""
+
+    class BadClient(DummyClient):
+        async def send_message(self, message):
+            raise RuntimeError("send blew up")
+
+    monkeypatch.setattr(server_module, "NotebookLMClient", DummyClient)
+    server = server_module.NotebookLMFastMCP(ServerConfig(default_notebook_id="abc"))
+    server.client = BadClient(server.config)
+
+    async def fake_ensure(self):
+        return self.client
+
+    server._ensure_client = MethodType(fake_ensure, server)
+    request = server_module.ChatRequest(message="hello", notebook_id=None)
+
+    with pytest.raises(NotebookLMError, match="Chat interaction failed"):
+        await server.app.tools["chat_with_notebook"](request)
 
 
 @pytest.mark.asyncio
@@ -324,7 +475,7 @@ async def test_navigate_to_notebook_tool_error(monkeypatch):
     server.client = BadClient(server.config)
 
     async def fake_ensure(self):
-        return None
+        return self.client
 
     server._ensure_client = MethodType(fake_ensure, server)
     request = server_module.NavigateRequest(notebook_id="xyz")
@@ -388,7 +539,7 @@ async def test_navigate_to_notebook_tool_success(monkeypatch):
     server.client = dummy
 
     async def fake_ensure(self):
-        return None
+        return self.client
 
     server._ensure_client = MethodType(fake_ensure, server)
     request = server_module.NavigateRequest(notebook_id="xyz")
@@ -504,3 +655,352 @@ async def test_main_handles_general_exception(monkeypatch):
 
     assert exc.value.code == 1
     assert any("Server error" in message for message in logs)
+
+
+# --------------------------------------------------------------------------- #
+# Notebook / source management tools (RPC engine) + the management guard.
+# --------------------------------------------------------------------------- #
+# Unique sentinels so the management-tool assertions test real wiring (the
+# server surfacing the client's value) rather than echoing a hardcoded payload.
+NB_LIST = [{"id": "nb1", "title": "First", "emoji": "📓", "source_count": 2}]
+NB_OBJ = {"id": "nb1", "title": "First", "emoji": "📓", "source_count": 2}
+SRC_LIST = [{"id": "s1", "title": "Src", "type": "pdf", "status": "ready"}]
+SRC_OBJ = {"id": "s1", "title": "Src", "type": "pdf", "status": "ready"}
+SUMMARY = "an-ai-generated-summary-3b8f"
+
+
+class ManagementClient(DummyClient):
+    """An RPC-style client that supports management. Records every call."""
+
+    supports_management = True
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.management_calls: list[tuple] = []
+
+    async def list_notebooks(self):
+        self.management_calls.append(("list_notebooks",))
+        return NB_LIST
+
+    async def create_notebook(self, title):
+        self.management_calls.append(("create_notebook", title))
+        return NB_OBJ
+
+    async def rename_notebook(self, notebook_id, new_title):
+        self.management_calls.append(("rename_notebook", notebook_id, new_title))
+        return NB_OBJ
+
+    async def delete_notebook(self, notebook_id):
+        self.management_calls.append(("delete_notebook", notebook_id))
+
+    async def get_notebook_summary(self, notebook_id):
+        self.management_calls.append(("get_notebook_summary", notebook_id))
+        return SUMMARY
+
+    async def list_sources(self, notebook_id):
+        self.management_calls.append(("list_sources", notebook_id))
+        return SRC_LIST
+
+    async def add_source_url(self, notebook_id, url):
+        self.management_calls.append(("add_source_url", notebook_id, url))
+        return SRC_OBJ
+
+    async def add_source_text(self, notebook_id, title, text):
+        self.management_calls.append(("add_source_text", notebook_id, title, text))
+        return SRC_OBJ
+
+    async def delete_source(self, notebook_id, source_id):
+        self.management_calls.append(("delete_source", notebook_id, source_id))
+
+
+def _management_server(monkeypatch, client_cls=ManagementClient):
+    """A server with an RPC config and a management-capable client wired in,
+    with ``_ensure_client`` stubbed to that client (no real init)."""
+    monkeypatch.setattr(server_module, "NotebookLMClient", DummyClient)
+    config = ServerConfig(default_notebook_id="abc", engine="rpc")
+    server = server_module.NotebookLMFastMCP(config)
+    client = client_cls(config)
+    server.client = client
+
+    async def fake_ensure(self):
+        return self.client
+
+    server._ensure_client = MethodType(fake_ensure, server)
+    return server, client
+
+
+def test_management_tools_registered(monkeypatch):
+    """All 9 management tools must be registered on the app."""
+    monkeypatch.setattr(server_module, "NotebookLMClient", DummyClient)
+    server = server_module.NotebookLMFastMCP(
+        ServerConfig(default_notebook_id="abc", engine="rpc")
+    )
+    expected = {
+        "list_notebooks",
+        "create_notebook",
+        "rename_notebook",
+        "delete_notebook",
+        "get_notebook_summary",
+        "list_sources",
+        "add_source_url",
+        "add_source_text",
+        "delete_source",
+    }
+    assert expected.issubset(server.app.tools.keys())
+
+
+@pytest.mark.asyncio
+async def test_list_notebooks_tool(monkeypatch):
+    server, client = _management_server(monkeypatch)
+    result = await server.app.tools["list_notebooks"]()
+    assert result["status"] == "success"
+    assert result["count"] == 1
+    # Surfaces the client's actual list (not a hardcoded payload).
+    assert result["notebooks"] == NB_LIST
+    assert client.management_calls == [("list_notebooks",)]
+
+
+@pytest.mark.asyncio
+async def test_create_notebook_tool(monkeypatch):
+    server, client = _management_server(monkeypatch)
+    request = server_module.CreateNotebookRequest(title="My NB")
+    result = await server.app.tools["create_notebook"](request)
+    assert result["status"] == "success"
+    assert result["notebook"] == NB_OBJ
+    # The title flowed through to the client unchanged.
+    assert client.management_calls == [("create_notebook", "My NB")]
+
+
+@pytest.mark.asyncio
+async def test_rename_notebook_tool(monkeypatch):
+    server, client = _management_server(monkeypatch)
+    request = server_module.RenameNotebookRequest(
+        notebook_id="nb1", new_title="Renamed"
+    )
+    result = await server.app.tools["rename_notebook"](request)
+    assert result["notebook"] == NB_OBJ
+    assert client.management_calls == [("rename_notebook", "nb1", "Renamed")]
+
+
+@pytest.mark.asyncio
+async def test_delete_notebook_tool(monkeypatch):
+    server, client = _management_server(monkeypatch)
+    request = server_module.NotebookIdRequest(notebook_id="nb1")
+    result = await server.app.tools["delete_notebook"](request)
+    assert result["status"] == "success"
+    assert result["notebook_id"] == "nb1"
+    assert client.management_calls == [("delete_notebook", "nb1")]
+
+
+@pytest.mark.asyncio
+async def test_get_notebook_summary_tool(monkeypatch):
+    server, client = _management_server(monkeypatch)
+    request = server_module.NotebookIdRequest(notebook_id="nb1")
+    result = await server.app.tools["get_notebook_summary"](request)
+    # Surfaces the client's unique summary string.
+    assert result["summary"] == SUMMARY
+    assert client.management_calls == [("get_notebook_summary", "nb1")]
+
+
+@pytest.mark.asyncio
+async def test_list_sources_tool(monkeypatch):
+    server, client = _management_server(monkeypatch)
+    request = server_module.NotebookIdRequest(notebook_id="nb1")
+    result = await server.app.tools["list_sources"](request)
+    assert result["count"] == 1
+    assert result["sources"] == SRC_LIST
+    assert client.management_calls == [("list_sources", "nb1")]
+
+
+@pytest.mark.asyncio
+async def test_add_source_url_tool(monkeypatch):
+    server, client = _management_server(monkeypatch)
+    request = server_module.AddSourceUrlRequest(
+        notebook_id="nb1", url="https://example.com"
+    )
+    result = await server.app.tools["add_source_url"](request)
+    assert result["source"] == SRC_OBJ
+    assert client.management_calls == [("add_source_url", "nb1", "https://example.com")]
+
+
+@pytest.mark.asyncio
+async def test_add_source_text_tool(monkeypatch):
+    server, client = _management_server(monkeypatch)
+    request = server_module.AddSourceTextRequest(
+        notebook_id="nb1", title="T", text="body"
+    )
+    result = await server.app.tools["add_source_text"](request)
+    assert result["source"] == SRC_OBJ
+    assert client.management_calls == [("add_source_text", "nb1", "T", "body")]
+
+
+@pytest.mark.asyncio
+async def test_delete_source_tool(monkeypatch):
+    server, client = _management_server(monkeypatch)
+    request = server_module.DeleteSourceRequest(notebook_id="nb1", source_id="s1")
+    result = await server.app.tools["delete_source"](request)
+    assert result["status"] == "success"
+    assert result["notebook_id"] == "nb1"
+    assert result["source_id"] == "s1"
+    assert client.management_calls == [("delete_source", "nb1", "s1")]
+
+
+@pytest.mark.asyncio
+async def test_management_tool_wraps_client_error(monkeypatch):
+    """A failure inside a management method is wrapped as NotebookLMError."""
+
+    class FailingMgmt(ManagementClient):
+        async def list_notebooks(self):
+            raise RuntimeError("rpc down")
+
+    server, _ = _management_server(monkeypatch, client_cls=FailingMgmt)
+    with pytest.raises(NotebookLMError, match="Failed to list notebooks"):
+        await server.app.tools["list_notebooks"]()
+
+
+# --------------------------------------------------------------------------- #
+# _require_management guard
+# --------------------------------------------------------------------------- #
+class NonManagementClient(DummyClient):
+    """A patchright-style client that does NOT support management."""
+
+    supports_management = False
+
+
+@pytest.mark.parametrize(
+    "tool_name,request_factory",
+    [
+        ("list_notebooks", lambda m: None),
+        ("create_notebook", lambda m: m.CreateNotebookRequest(title="t")),
+        (
+            "rename_notebook",
+            lambda m: m.RenameNotebookRequest(notebook_id="n", new_title="t"),
+        ),
+        ("delete_notebook", lambda m: m.NotebookIdRequest(notebook_id="n")),
+        ("get_notebook_summary", lambda m: m.NotebookIdRequest(notebook_id="n")),
+        ("list_sources", lambda m: m.NotebookIdRequest(notebook_id="n")),
+        (
+            "add_source_url",
+            lambda m: m.AddSourceUrlRequest(notebook_id="n", url="u"),
+        ),
+        (
+            "add_source_text",
+            lambda m: m.AddSourceTextRequest(notebook_id="n", title="t", text="x"),
+        ),
+        (
+            "delete_source",
+            lambda m: m.DeleteSourceRequest(notebook_id="n", source_id="s"),
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_management_guard_rejects_non_management_engine(
+    monkeypatch, tool_name, request_factory
+):
+    """Every management tool must raise NotebookLMError mentioning the 'rpc'
+    engine when the active client does not support management."""
+    monkeypatch.setattr(server_module, "NotebookLMClient", NonManagementClient)
+    config = ServerConfig(default_notebook_id="abc", engine="patchright")
+    server = server_module.NotebookLMFastMCP(config)
+    server.client = NonManagementClient(config)
+
+    async def fake_ensure(self):
+        return self.client
+
+    server._ensure_client = MethodType(fake_ensure, server)
+
+    tool = server.app.tools[tool_name]
+    request = request_factory(server_module)
+    with pytest.raises(NotebookLMError, match="rpc"):
+        if request is None:
+            await tool()
+        else:
+            await tool(request)
+
+
+@pytest.mark.asyncio
+async def test_require_management_passes_for_rpc_client(monkeypatch):
+    """_require_management returns the client when it supports management."""
+    server, client = _management_server(monkeypatch)
+    assert server._require_management() is client
+
+
+def test_require_management_raises_when_no_client(monkeypatch):
+    monkeypatch.setattr(server_module, "NotebookLMClient", DummyClient)
+    server = server_module.NotebookLMFastMCP(
+        ServerConfig(default_notebook_id="abc", engine="rpc")
+    )
+    server.client = None
+    with pytest.raises(NotebookLMError, match="rpc"):
+        server._require_management()
+
+
+# --------------------------------------------------------------------------- #
+# _build_client engine dispatch
+# --------------------------------------------------------------------------- #
+def test_build_client_patchright_uses_injectable_symbol(monkeypatch):
+    """engine='patchright' must construct the module-level NotebookLMClient
+    (the injectable symbol), passing the config through."""
+    built = []
+
+    class MarkerClient:
+        def __init__(self, config):
+            built.append(config)
+
+    monkeypatch.setattr(server_module, "NotebookLMClient", MarkerClient)
+    config = ServerConfig(default_notebook_id="abc", engine="patchright")
+    server = server_module.NotebookLMFastMCP(config)
+
+    client = server._build_client()
+    assert isinstance(client, MarkerClient)
+    assert built == [config]
+
+
+def test_build_client_rpc_constructs_rpc_client(monkeypatch):
+    """engine='rpc' must construct a NotebookLMRPCClient (patched so no real
+    backend is built), passing the config through."""
+    import notebooklm_mcp.client_rpc as client_rpc_module
+
+    built = []
+
+    class MarkerRPCClient:
+        supports_management = True
+
+        def __init__(self, config):
+            built.append(config)
+
+    monkeypatch.setattr(client_rpc_module, "NotebookLMRPCClient", MarkerRPCClient)
+    # The patchright branch symbol must NOT be used for engine='rpc'.
+    monkeypatch.setattr(server_module, "NotebookLMClient", DummyClient)
+    config = ServerConfig(default_notebook_id="abc", engine="rpc")
+    server = server_module.NotebookLMFastMCP(config)
+
+    client = server._build_client()
+    assert isinstance(client, MarkerRPCClient)
+    assert built == [config]
+
+
+def test_build_client_defaults_to_rpc_when_engine_missing(monkeypatch):
+    """When the config has no ``engine`` attribute at all, _build_client falls
+    back to the RPC engine (getattr default)."""
+    import notebooklm_mcp.client_rpc as client_rpc_module
+
+    built = []
+
+    class MarkerRPCClient:
+        supports_management = True
+
+        def __init__(self, config):
+            built.append(config)
+
+    monkeypatch.setattr(client_rpc_module, "NotebookLMRPCClient", MarkerRPCClient)
+    monkeypatch.setattr(server_module, "NotebookLMClient", DummyClient)
+
+    config = ServerConfig(default_notebook_id="abc", engine="rpc")
+    server = server_module.NotebookLMFastMCP(config)
+    # Simulate an older config object missing the engine field.
+    delattr(server.config, "engine")
+
+    client = server._build_client()
+    assert isinstance(client, MarkerRPCClient)
+    assert built == [config]

--- a/uv.lock
+++ b/uv.lock
@@ -1,12 +1,9 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 
 [manifest]
-constraints = [
-    { name = "pydantic", specifier = ">=2.8.0,<3.0" },
-    { name = "selenium", specifier = ">=4.20.0,<5.0" },
-]
+constraints = [{ name = "pydantic", specifier = ">=2.8.0,<3.0" }]
 build-constraints = [
     { name = "setuptools", specifier = ">=65.0" },
     { name = "wheel" },
@@ -172,11 +169,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2025.8.3"
+version = "2026.5.20"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dc/67/960ebe6bf230a96cda2e0abcf73af550ec4f090005363542f0765df162e0/certifi-2025.8.3.tar.gz", hash = "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407", size = 162386, upload-time = "2025-08-03T03:07:47.08Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/48/1549795ba7742c948d2ad169c1c8cdbae65bc450d6cd753d124b17c8cd32/certifi-2025.8.3-py3-none-any.whl", hash = "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5", size = 161216, upload-time = "2025-08-03T03:07:45.777Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
 ]
 
 [[package]]
@@ -619,6 +616,92 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/6e/802acd792aebb2256fbbee8cacf2727faaeb6f240ac11008f09eae4414bc/greenlet-3.5.1.tar.gz", hash = "sha256:5a56aeb7d5d9cc4b3a735efb5095bd4b4f6f0e4f93e5ca876d0e2315137b7829", size = 197356, upload-time = "2026-05-20T15:05:03.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/21/117c8710abb7f146d804a124c07eb5964a60b90d02b72452885aecc18efa/greenlet-3.5.1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:7eacb17a9d41538a2bc4912eba5ef13823c83cb69e4d141d0813debe7163187f", size = 283510, upload-time = "2026-05-20T13:12:26.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/f7/6762a56fa5f6c2295c449c6524e10ce481e381c994cc44d9d03aef0700fb/greenlet-3.5.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e5cc9606aa5f4e0bde0d3bd502b44f743864c3ffa5cfa1011b1e30f5aa02366f", size = 599696, upload-time = "2026-05-20T14:00:02.906Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/05/85a511e68ee109aff0aa00b4b497806091dd2d82ce209e49c6e801bd5d92/greenlet-3.5.1-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c3d35f87c7253b715d13d679e0783d845910144f282cb939fe1ba4ac8616269c", size = 612618, upload-time = "2026-05-20T14:05:39.202Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/19/60df45065b2981ff894fdd51e7c99a3a4b107412822b083d88d5d528f663/greenlet-3.5.1-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:00929c98ec525fd9bf075875d8c5f6a983a90906cdf78a66e6de2d8e466c2a19", size = 619237, upload-time = "2026-05-20T14:09:06.421Z" },
+    { url = "https://files.pythonhosted.org/packages/89/b8/8b83d18ae07c46c019617f35afd7b47aab7f9b4fbb12fc637d681e10bdd8/greenlet-3.5.1-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:540dae7b956209af4d70a3be35927b4055f617763771e5e84a5255bea934d2f5", size = 612947, upload-time = "2026-05-20T13:14:23.469Z" },
+    { url = "https://files.pythonhosted.org/packages/26/9a/4ba4c2bc9d9df5f41bb8943fb7bb11e440352e6b9c2e36716b6e85f8b82d/greenlet-3.5.1-cp310-cp310-manylinux_2_39_riscv64.whl", hash = "sha256:001775efe7b8e758861294c7a27c28af87f3f3f1c20468a2bc618c45b346c061", size = 415653, upload-time = "2026-05-20T14:01:36.999Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/14/ad1f9fc9b82384c010212464a3702bd911f95dab2f1180bc6fbcfb1f958c/greenlet-3.5.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ed8cdb691169715a9a492844a83246f090182247d1a5031dc78a403f68ba1e97", size = 1571425, upload-time = "2026-05-20T14:02:22.671Z" },
+    { url = "https://files.pythonhosted.org/packages/46/1c/43b8203cf10f4292c9e3d270e9e5f5ade79115a0a0ca5ea6f1be5f8915a7/greenlet-3.5.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9d59e840387076a51016777a9328b3f2c427c6f9208a6e958bad251be50a648d", size = 1638688, upload-time = "2026-05-20T13:14:30.026Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/6e/0344b1e99f58f71715456e46492101fd2daa408957b8186ade0a4b515da7/greenlet-3.5.1-cp310-cp310-win_amd64.whl", hash = "sha256:b9152fca4a6466e114aaec745ae61cba739903a109754a9d4e1262f01e9259b1", size = 237763, upload-time = "2026-05-20T13:11:35.659Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3c/ff890b466eaba2b0f5e6bdfff025f8c75f41b8ffdc3dbc3d24ad261e764a/greenlet-3.5.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:73f78f9b9f0a5c06e5c946ba1e8e36f5114923b6be109ee618c54f079c3ea14f", size = 284764, upload-time = "2026-05-20T13:09:10.204Z" },
+    { url = "https://files.pythonhosted.org/packages/81/0e/5e5457be3d256918f6a4756f073548a3f0190836e2cc94aa6d0d617a940b/greenlet-3.5.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a0cbed8bb44e23c5b199f888f4e4ce096b45ad9f25ff74a7ad0213875e936bb2", size = 603479, upload-time = "2026-05-20T14:00:04.757Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e1/f89a21d58d308298e6f275f13a1b472ed96c680b601a371b08be6a725989/greenlet-3.5.1-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a203a8bd0acb0701653d3bbb26e404854a68674139ed5cbb778830f42b09bb33", size = 615495, upload-time = "2026-05-20T14:05:40.87Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/8fd452fd81adb9ec79c8275c1375702ab0fd6bee4952da12eaa09b9508d8/greenlet-3.5.1-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6ebeb75c81211f5c702576cf81f315e77e23cfdb2c7c6fcb9dd143e6de35c360", size = 623515, upload-time = "2026-05-20T14:09:07.853Z" },
+    { url = "https://files.pythonhosted.org/packages/75/de/af6cef182862d2ccd6975440d21c9058a77c3f9b469abf94e322dfd2e0e3/greenlet-3.5.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a271fcd66c74615cda6a964fda3f304267a12e50a084472218a39bb0376f563", size = 614754, upload-time = "2026-05-20T13:14:24.947Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bc/c318aa9f3ffc77320fddcee3d892be957b42e2ff947198d9450b004f3a38/greenlet-3.5.1-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:017a544f0385d441e88714160d089d6900ef46c9eff9d99b6715a5ef2d127747", size = 418439, upload-time = "2026-05-20T14:01:38.446Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c6/50e520283a9f19388a7326b05f9e8637e566003475eacaadad04f558c68d/greenlet-3.5.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ded7b068c7c31c1a8657d4fd42d886b3e051ae29f88b80c5ff9d502257b0f071", size = 1574097, upload-time = "2026-05-20T14:02:24.003Z" },
+    { url = "https://files.pythonhosted.org/packages/21/1c/13abd1f4860d987fa5e1170a01930d6e6cd40d328de487a3c9fdaff0ffd0/greenlet-3.5.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d0932b81d72f552ded9d810d00021b64d89f2195a91ce115b893f943b7a4ab3c", size = 1641058, upload-time = "2026-05-20T13:14:31.83Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/56/5f332b7705545eac2dc01b4e9254d24a793f2656d55d5cc6b94ee59d22ae/greenlet-3.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:88e300d136eac057b2397aa1cfd7328b4c87c7eb66a09c7bc6a1292234db474e", size = 238089, upload-time = "2026-05-20T13:14:03.229Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a9/a3c2fa886c5b94863fb0e61b3bc14610b7aa94cf4f17f8741b11708305fc/greenlet-3.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:cc6ab7e555c8a112ad3a76e368e86e12a2754bcae1652a5602e133ec7b635523", size = 234989, upload-time = "2026-05-20T13:08:27.715Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/37/4549f149c9797c21b32c2683c33522af22522099de128b2406672526d005/greenlet-3.5.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:fa4f98af3a528f0c3fd592a26df7f376f93329c8f4d987f6bb979057af8bf5e2", size = 286220, upload-time = "2026-05-20T13:07:28.463Z" },
+    { url = "https://files.pythonhosted.org/packages/38/ff/a4f436709716965eaab9f36ea7b906c8a927fbe32fb1372a2071d964f6b1/greenlet-3.5.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffea73584b216150eab159b6d12348fb253e68757974de1e2c40d8a318ac89ed", size = 601585, upload-time = "2026-05-20T14:00:06.141Z" },
+    { url = "https://files.pythonhosted.org/packages/65/ad/54bc3fcee3ad368a61b19b67d88117f7a8c29727bf71fffdeda81fbd946e/greenlet-3.5.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1072b4f9edcc1e192d9283a66a3e68d6b84c561de33a83d7858beb9ba1effe10", size = 614215, upload-time = "2026-05-20T14:05:42.675Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/6c/de5b1b388cd2d9fbdfeab324863daba37d54e6e233ddbefd70b385a8c591/greenlet-3.5.1-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:89101bfd5011e069be974903cb3a4e4523845e4ece2d62dcd8d358933c0ef249", size = 620094, upload-time = "2026-05-20T14:09:09.18Z" },
+    { url = "https://files.pythonhosted.org/packages/40/69/b91cda0647df839483201545913514c2827ebea5e5ccdf931842763bc127/greenlet-3.5.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:add5217d68b31130f0beca584d7fef4878327d2e31642b66618a14eef312b63b", size = 611358, upload-time = "2026-05-20T13:14:26.37Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/43/1204baffab8a6476464795a7ccf394a3248d4f22c9f87173a15b36b6d971/greenlet-3.5.1-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:e6cd99ea59dd5d89f0c956606571d79bfe6f68c9eb7f4a4083a41a7f1587edee", size = 422782, upload-time = "2026-05-20T14:01:39.597Z" },
+    { url = "https://files.pythonhosted.org/packages/59/90/3cf77e080350cd02fa307bb2abf05df48f4482c240275bbd2c203ba8bb1c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a5ea42a752d47a145eae922b605cd1634665ac3d5ec1e72402d5048e8d60d207", size = 1570475, upload-time = "2026-05-20T14:02:25.29Z" },
+    { url = "https://files.pythonhosted.org/packages/65/2c/18cece62045e74598c3c393f70dce4a63f56222015ba29a5d4eeb04f764c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c5551170cf4f5ff5623e9af81323751979fee2c731e2287b61f73cd27257b823", size = 1635625, upload-time = "2026-05-20T13:14:34.027Z" },
+    { url = "https://files.pythonhosted.org/packages/30/f5/310d104ddf41eb5a70f4c268d22508dfb0c3c8e86fec152be34d0d2ed819/greenlet-3.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3c8bb982ad117d29478ef8f5533e97df21f1e2befd17a299257b0c96d1371c0b", size = 238791, upload-time = "2026-05-20T13:10:39.018Z" },
+    { url = "https://files.pythonhosted.org/packages/62/90/ceca11f504cd23a8047a3dea31919adc48df9b626dd0c13f0d858734fdfd/greenlet-3.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:80eb4b04dadc4e67df3fae179a32c4706a3f495bc7f22fc8a81115d5f5512188", size = 235580, upload-time = "2026-05-20T13:08:45.056Z" },
+    { url = "https://files.pythonhosted.org/packages/27/69/7f7e5372d998b81001899b1c0823c957aa413ba0f2662e65821611cc31e4/greenlet-3.5.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:51518ff74664078fc51bffcc6fc529b0df5ae58da192691cee765d45ce944a2b", size = 285060, upload-time = "2026-05-20T13:08:51.899Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/bf/387f9b6b865fd2ae0d0be09e0004827295a01b71be76ed350dd1e28a91a4/greenlet-3.5.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ffdb3c0bb002c99cd8f298957e046c3dbf6006b5b7cdf11a4e19194624a0a0a", size = 604370, upload-time = "2026-05-20T14:00:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f5/169ce3d4e4c67291bd18f8cbe0299c9f3e45102c7f1fb3c14780c93e4532/greenlet-3.5.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7715a5a2c3378ba602c3a440558261e13a820bb53a82693aacd7b7f6d964e283", size = 616987, upload-time = "2026-05-20T14:05:44.237Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ba/c24110c55dffa55aa6e1d98b45310da33801aeba7686ff0190fe5d46fd32/greenlet-3.5.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d40a890035c0058cadbdc4af7569800fd28a0e527a0fdbb7b5f9418f176846ce", size = 622911, upload-time = "2026-05-20T14:09:10.598Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e5/7f2e41d5273be07e77560d61ea4e56485b4d6c316d2a84518c62d1364061/greenlet-3.5.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc71ff466927a201b08305acac451ebe1aedfcea002f62f1f2f2ac2ac1e6a135", size = 613911, upload-time = "2026-05-20T13:14:27.539Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/7b/d20db2e8a5ad6c038702f3179b136f93f0a3d1a21a0c0777f3e470cdf4b2/greenlet-3.5.1-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:67821bb03e4e98664490edb787ff6af501194c29bbee0f5c1dfdcf1dc3d9d436", size = 425228, upload-time = "2026-05-20T14:01:40.837Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a4/fbdc67579b73615a1f91615e814303cc71e06128f7baaba87be79b8fb90c/greenlet-3.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cd443683db272ebaaca03af98c0b063ab30db70ea8a31a1559f35e3f7b744ccd", size = 1570689, upload-time = "2026-05-20T14:02:27.225Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b4/77abbe35078be39718a46cd49caf16bceb35662f97a34101dca28aa98e47/greenlet-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:089fff7a6ce8d9316d1f65ebc00273a56be258c1725b32b94de90a3a979557e1", size = 1635602, upload-time = "2026-05-20T13:14:36.344Z" },
+    { url = "https://files.pythonhosted.org/packages/37/f7/129f27ca700845b8ee8ca88ce7f43435a1239c2eddb7677fc938822762cf/greenlet-3.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:110a1ca7b49b014b097f6078272c3f4ed31af45b254de5228b79adba879f6af9", size = 238683, upload-time = "2026-05-20T13:11:50.57Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/5c/a485a36e87df8d8fd0632ee01511244f5156a20ed3746cc6599340326395/greenlet-3.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:f16ba1efc0715b680a18b8123d90dad887c6112ae3555b4b5c32c149540c6b4e", size = 235499, upload-time = "2026-05-20T13:12:42.028Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cb/c62454606daf5640369c94d8a9dd540599b1bfc090e2d2180cb77f4038d2/greenlet-3.5.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8ab31c9de8651a2facdd5c5bb0011f2380dd1a7af78ce2adf4b56095294fc07", size = 285579, upload-time = "2026-05-20T13:08:56.396Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/71/c4270398c2eba968a6071af1dfbdcaeee6ec1c24bc8b435b8cc452700da6/greenlet-3.5.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e300185139abc337ade480c327183adf42a875ac7181bfe66d7d4efea31fbea", size = 651106, upload-time = "2026-05-20T14:00:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ab/71e34b78a44ec271fb5f550c17bc46d301ddc5953890d935f270b0dcdb5a/greenlet-3.5.1-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7ffdb990dcaa0234cf9845aead5df2e3c3a8b6507d409274dd87e0d5ab05ffc2", size = 663478, upload-time = "2026-05-20T14:05:45.88Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/2d/2d80842910da44f78c286532d084b8a5c3717c844ae80ceb3858738ae89a/greenlet-3.5.1-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c09df69dc1712d131332054a858a3e5cca400967fa3a672e2324fbb0971448c", size = 667767, upload-time = "2026-05-20T14:09:12.15Z" },
+    { url = "https://files.pythonhosted.org/packages/77/96/4efd6fa5c62c85426a0c19077a586258ebc3a2a146ff2493e4312a697a22/greenlet-3.5.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2f82b3597e9d83b63408affed0b48fd0f54935edac4302237b9a837be0dae33c", size = 660800, upload-time = "2026-05-20T13:14:29.129Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d3/dad2eecedfbb1ed7050a20dcfae40c1442b74bc7423608be2c7e03ee7133/greenlet-3.5.1-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:a4764e0bfc6a4d114c865b32520805c16a990ef5f286a514413b05d5ecd6a23d", size = 470786, upload-time = "2026-05-20T14:01:42.064Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/e0/6c71401a25cac7000261304e866a2f2cc04dc74810d40e2f118aa4799495/greenlet-3.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c0141e37414c10164e702b8fb1473304221ad98f71600850c6ef7ff4880feba0", size = 1617518, upload-time = "2026-05-20T14:02:28.662Z" },
+    { url = "https://files.pythonhosted.org/packages/41/26/c5c06643e8c0af9e7bf18e16cb51d0ab7625155f0392e1c9015d66d556cd/greenlet-3.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:50ae25a67bea74ea41fb14b960bc532df73eb713417b2d61892dced82fe8d3bc", size = 1681593, upload-time = "2026-05-20T13:14:39.417Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/bd/e11a108317485075e68af9d23039619b86b28130c3b50d227d42edece64b/greenlet-3.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:8a17c42330e261299766b75ac1ea32caa437a9453c8f65d16a13140db378ecd3", size = 239800, upload-time = "2026-05-20T13:09:30.128Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f8/8e8e8417b7bf28639a5a56356ef934d0375e1d0c70a57e04d7701e870ffe/greenlet-3.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:7b5f5fae05b8ac6d176a61b60c394a8cbdc2b5b91b81793066e68745cf165e54", size = 236862, upload-time = "2026-05-20T13:09:10.498Z" },
+    { url = "https://files.pythonhosted.org/packages/90/12/41bf27fde4d3605d3773ae57751eda182b8be2f5398011c041173b1d9534/greenlet-3.5.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:ea8da1e900d758d078810d4255d8c6aa572181896a31ec79d779eb79c3adc9ad", size = 293637, upload-time = "2026-05-20T13:12:35.529Z" },
+    { url = "https://files.pythonhosted.org/packages/44/44/ba14b23e9757707050c2f397d305bbcae62e5d7cad122f8b6baec5ae4a1f/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a19570c52a21420dcbc94e661994bc325c0b5b11304540fed514586da5dc8f2e", size = 650840, upload-time = "2026-05-20T14:00:11.079Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/37/5ddc2b686a6844f91abecef43411842426da2e1573f60b49ecf2547f4ae1/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3d955c89b75eeca4723d7cc14135f393cd47c32e2a6cb4a8e4c6e760a26b0986", size = 656416, upload-time = "2026-05-20T14:05:47.118Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/46/5987dcd1a2570ba84f3b187536b2ca3ae97613387e57f5cfa99df068fe5e/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ea37d5a157eb9493820d3792ac4ece28619a394391d2b9f2f78057d396ff0f0f", size = 656607, upload-time = "2026-05-20T14:09:13.949Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f0/d17510297c35a2992712f0bf84de3779749999f7d3d63aa1f09db7c62dbe/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de2daaaebd1a5aa88c49045b6baf9310b3263796bd88db713edf37cf53e7bb4e", size = 654397, upload-time = "2026-05-20T13:14:30.696Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c1/6da0a9ddcc29d7e51ef14883fa3dc1e53b3f4ffba00582106c7bf55da1d8/greenlet-3.5.1-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:8d8a23250ea3ec7b36de8fa4b541e9e2db3ee82915cc060ab0631609ad8b28de", size = 488287, upload-time = "2026-05-20T14:01:43.143Z" },
+    { url = "https://files.pythonhosted.org/packages/37/eb/147387705bb89092645b012586e7273cb5ed3c90ef7eaf3a69173eaf0209/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bfbd69cc349e43bf3a8ae1c85548ff0718efc887615c2db16c3833d7b0b072d", size = 1614469, upload-time = "2026-05-20T14:02:30.192Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/4e/37ee0da7732b7aa9896f17e15579a9df34b9fcb9dd494f0adfa749af6623/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4378720dd888136c27215a0214d32a4d37c3852765d45bc37aad0623423cfd78", size = 1675115, upload-time = "2026-05-20T13:14:40.972Z" },
+    { url = "https://files.pythonhosted.org/packages/57/f3/97dfcf4a6eb5077f8a672234216fb5923eb89f2cab7081cb10b2cf75b605/greenlet-3.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:45718441607f9325d948db98cbc691276059316d0358c188c246da4e1d4d23d2", size = 245246, upload-time = "2026-05-20T13:12:22.646Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/73/d7f72e34b582f694f4a9b248162db7b09cc458a259ba8f0c0bfa1a34ea7d/greenlet-3.5.1-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:2baee5ca02031757ffe8cc3d69f0cc0aec7065ce362622da74f32d3bcab1c541", size = 285575, upload-time = "2026-05-20T13:12:07.043Z" },
+    { url = "https://files.pythonhosted.org/packages/df/59/fa9c6e87dc8ad27a95dabe2f29f372b733d05a8a67470f6c901ed9975655/greenlet-3.5.1-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b1ec3274918a81d3ea778b9e75b56b72b33f300edb6cf7f3a7fe1dae56683de", size = 656428, upload-time = "2026-05-20T14:00:12.556Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f9/e753408871eaa61dfe35e619cfc67512b036fde99893685d50eea9e07146/greenlet-3.5.1-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:111e2390ffffc47d5840b01711dd7fac07d4c09283d0283e7f3264b14e284c64", size = 667064, upload-time = "2026-05-20T14:05:48.662Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/74/807a047255bf1e09303627c46dc043dca596b6958a354d904f32ab382005/greenlet-3.5.1-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:10a9a1c0bfbc93d41156ffcb90c75fbc05544054faf15dcc1fdf9765f8b607f0", size = 672962, upload-time = "2026-05-20T14:09:15.532Z" },
+    { url = "https://files.pythonhosted.org/packages/96/27/5565b5b40389f1c7753003a07e21892fda8660926787036d5bc0308b8113/greenlet-3.5.1-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e630136e905fe5ff43e86945ae41220b6d1470956a39220e708110ac48d01ea5", size = 665697, upload-time = "2026-05-20T13:14:32.943Z" },
+    { url = "https://files.pythonhosted.org/packages/76/32/19d4e13225193c29b13e308015223f7d75fd3d8623d49dd19040d2ce8ec1/greenlet-3.5.1-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:ef08c1567c78074b22d1a200183d52d04a14df447bf70bcbb6a3507a48e776fc", size = 476047, upload-time = "2026-05-20T14:01:44.39Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/82/e7de4178c0c2d1c9a5a3be3cc0b33e46a85b3ee4a77c071bf7ad8600e079/greenlet-3.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:975eac34b44a7077ca4d421348455b94f0f518246a7f14bc6d2fdcfe5b584368", size = 1621256, upload-time = "2026-05-20T14:02:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/00/10/f2dddcf7dacac17dfc68691809589adad06135eb28930429cf58a6467a2f/greenlet-3.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:9ab3c3a0b2ae6198e67c898dad5215a49f9ae0d0081b3c3ec59f333e39eeca26", size = 1685956, upload-time = "2026-05-20T13:14:42.55Z" },
+    { url = "https://files.pythonhosted.org/packages/22/17/4a232b32133230ada52f70e9d7f5b65b0caef8772f01849bd8d149e7e4ca/greenlet-3.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:cbfc69be86e10dcfef5b1e6269d1d6926552aa89ee39e1de3353360c1b6989ab", size = 239802, upload-time = "2026-05-20T13:13:15.481Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ae/4e623a7e6d4d2a5f4cb8e4c82de4169fc637942caae68d6e676b8a128ac5/greenlet-3.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:92fd6d44ac5e5a887c8a5dc4a8ba0ba908527c31c12f78c6bc7dcfe8aab279f6", size = 236853, upload-time = "2026-05-20T13:15:37.301Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/57/816d9cff29119da3505b3d6a5e14a8af89006ac36f47f891ff293ee05af1/greenlet-3.5.1-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:a6fdf2433a5441ef9a95464f7c3e674775da1c8c1177fff311cee1acad4626ed", size = 293877, upload-time = "2026-05-20T13:10:19.078Z" },
+    { url = "https://files.pythonhosted.org/packages/23/a1/59b0a7c7d140ff1a75626680b9a9899b79a9176cab298b394968fb023295/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7546556f0d649f99f6a361098a55f761181bb2ea12ff150bb16d26092ad88244", size = 655333, upload-time = "2026-05-20T14:00:14.758Z" },
+    { url = "https://files.pythonhosted.org/packages/72/1b/5efe127597625042218939d01855109f352779050768b670b52edcc16a6c/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d5ee3ea898009fa898f85f9982255d35278c477bebe185beca249cab42d4526c", size = 659443, upload-time = "2026-05-20T14:05:50.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/9d/1dcdf7b95ab3cf8c7b6d7277c18a5e167312f2b362ddfcc5d5e6d8d84b43/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a57b0d05a0448eed231d59c0ceb287dde984551e54cbc51ac2d4865712838e9c", size = 659998, upload-time = "2026-05-20T14:09:16.912Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/6d/c404246ea4d22d097a7426d0efb5b781bd7eb67715f09e79001bd552ab18/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5c81f74d204d3edd136ebfd50dce53acbb776995d721a0fe801626cfc93b8cd", size = 658356, upload-time = "2026-05-20T13:14:35.091Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7e/c4959664fc231d587d66d8e81f2095e98056ba1954beafdcbe635e251052/greenlet-3.5.1-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:b0703c2cef53e01baec47f7a3868009913ad71ec678bbecb42a6f40895e4ce62", size = 494470, upload-time = "2026-05-20T14:01:45.611Z" },
+    { url = "https://files.pythonhosted.org/packages/51/02/f8ee37fb6d2219329f350af241c27fcf12df57e723d11f6fc6d3bacdadaa/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:2c18ef16bf6d4dd410e4dd52996888ea1497be26892fe5bbc73580aba4287b8e", size = 1619216, upload-time = "2026-05-20T14:02:33.403Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c5/3dc9475ace2c7a3680da12372cddd7f1ac874eb410a1ac48d3e9dab83782/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:17d86354f0ae6b61bf9be5148d0dd34e06c3cb7c602c671f79f29ac3b150e659", size = 1678427, upload-time = "2026-05-20T13:14:43.71Z" },
+    { url = "https://files.pythonhosted.org/packages/df/4e/750c15c317a41ffb36f0bf40b933e3d744a7dede61889f74443ea69690cf/greenlet-3.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:e7516cf6ae6b8a582c2770a0caed47b8a48373ed732c33d69a72913ae6ac923e", size = 245225, upload-time = "2026-05-20T13:13:59.366Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/fd/d3baea2eeb7b617efd47e87ca06e2ec2c6118d303aa9e918e0ce16eadc10/greenlet-3.5.1-cp315-cp315t-win_arm64.whl", hash = "sha256:5028648bf2253ec4745add746129d3904121fa7fe871a76bed23c5720573ce0a", size = 239590, upload-time = "2026-05-20T13:13:37.382Z" },
 ]
 
 [[package]]
@@ -1308,14 +1391,14 @@ dependencies = [
     { name = "click" },
     { name = "fastmcp" },
     { name = "loguru" },
+    { name = "notebooklm-py" },
+    { name = "patchright" },
     { name = "psutil" },
     { name = "pydantic" },
     { name = "rich" },
-    { name = "selenium" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "trio" },
     { name = "typing-extensions" },
-    { name = "undetected-chromedriver" },
 ]
 
 [package.dev-dependencies]
@@ -1363,14 +1446,14 @@ requires-dist = [
     { name = "click", specifier = ">=8.0.0" },
     { name = "fastmcp", specifier = ">=2.0.0" },
     { name = "loguru", specifier = ">=0.7.2" },
+    { name = "notebooklm-py", specifier = ">=0.7" },
+    { name = "patchright", specifier = ">=1.60.1" },
     { name = "psutil", specifier = ">=5.9.0" },
     { name = "pydantic", specifier = ">=2.8.2" },
     { name = "rich", specifier = ">=13.0.0" },
-    { name = "selenium", specifier = ">=4.22.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
     { name = "trio", specifier = ">=0.26.0" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
-    { name = "undetected-chromedriver", specifier = ">=3.5.4" },
 ]
 
 [package.metadata.requires-dev]
@@ -1409,6 +1492,21 @@ test = [
     { name = "pytest-asyncio", specifier = ">=0.21.0" },
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-mock", specifier = ">=3.11.0" },
+]
+
+[[package]]
+name = "notebooklm-py"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "filelock" },
+    { name = "httpx" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/ad/44b3f03c0e95a9521fd9802cf41b12595d136a932863bb8ddf84601a017f/notebooklm_py-0.7.1.tar.gz", hash = "sha256:7e9a3c842388def3d81a3a1574846fc77bb485df6811a1e3cdcc1cb5906e43f9", size = 10962378, upload-time = "2026-06-07T03:38:47.077Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/04/de3c57d075cf721b539e8f28969fe1ca567ccac82fc7696cb44f75a28776/notebooklm_py-0.7.1-py3-none-any.whl", hash = "sha256:02647efdb6a725b2a0259df78271a22723c0d304f23fe41ae1ac6a302f3d4907", size = 784212, upload-time = "2026-06-07T03:38:44.98Z" },
 ]
 
 [[package]]
@@ -1509,6 +1607,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4f/78/d9b09ba24bb36ef8b83b71be547e118d46214735b6dfb39e4bfde0e9b9dd/parse-1.20.2.tar.gz", hash = "sha256:b41d604d16503c79d81af5165155c0b20f6c8d6c559efa66b4b695c3e5a0a0ce", size = 29391, upload-time = "2024-06-11T04:41:57.34Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/31/ba45bf0b2aa7898d81cbbfac0e88c267befb59ad91a19e36e1bc5578ddb1/parse-1.20.2-py2.py3-none-any.whl", hash = "sha256:967095588cb802add9177d0c0b6133b5ba33b1ea9007ca800e526f42a85af558", size = 20126, upload-time = "2024-06-11T04:41:55.057Z" },
+]
+
+[[package]]
+name = "patchright"
+version = "1.60.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/26/c1e858fd1acc63e410b3d33243955f36d2a0814487b97a7aa604ad2baffd/patchright-1.60.1-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:e9492100d4e2a85ff92fc3a668dd16dee03f21df6e559c7b9f7c71e86ff48c6b", size = 43458936, upload-time = "2026-06-03T12:11:50.892Z" },
+    { url = "https://files.pythonhosted.org/packages/55/dd/2dd8e4e02489ec8fd57ad93dec9ef444b6f42adcc4fe95df30237c92841d/patchright-1.60.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:20bd806df2469b451ccd2ea10f5f944ceb0e0d83c716f5752b0c956c1ee59476", size = 42245629, upload-time = "2026-06-03T12:11:56.098Z" },
+    { url = "https://files.pythonhosted.org/packages/54/cc/0fa0bedec61045fd9068682e3695557b622c483f829d341093879ec8dbd9/patchright-1.60.1-py3-none-macosx_11_0_universal2.whl", hash = "sha256:9fd15a64c0ca80740dc2a3f41cda336a06a2ed6068d0ab893172654290b06e6b", size = 43458935, upload-time = "2026-06-03T12:12:01.077Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/c2/4b8f69de0a20d90792980c43c0e60b10b801e08cf0224ccc8a8266e1fffb/patchright-1.60.1-py3-none-manylinux1_x86_64.whl", hash = "sha256:547e7bfb813102309789cc42933780e5fdf7c4727de59fb2791e64bd1298a7f3", size = 47451519, upload-time = "2026-06-03T12:12:06.645Z" },
+    { url = "https://files.pythonhosted.org/packages/db/fc/9fd6a70818cf0bc3b62574af483d762963cb65ca0a369826a0536faffe41/patchright-1.60.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:023945a2fd30219a284721ca36385bd44075ae7b53071dc1da38036b6dbe88ec", size = 47139153, upload-time = "2026-06-03T12:12:12.047Z" },
+    { url = "https://files.pythonhosted.org/packages/08/bc/81fb621e5ab4131e6f324c9ba6cb2a9f3b146c92f12484bec95efe8c8347/patchright-1.60.1-py3-none-win32.whl", hash = "sha256:05b98a6afdbe7e6645fe223009c47cc8e7859df55fd8ce9d8a9925b3389b0ee1", size = 37886460, upload-time = "2026-06-03T12:12:16.598Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8e/fff80350ed2c2c1f62145d667070799c60ca9e9b28d54e4f751f0b4f8da6/patchright-1.60.1-py3-none-win_amd64.whl", hash = "sha256:51b306ed55cd58f1bca24641458f5c9f7e86a1f1727dcffdead669cfe4c0a485", size = 37886465, upload-time = "2026-06-03T12:12:21.448Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b8/b6d1bfe98a420c1ccfb2f23a7bb2b4cdb40170907bae638e7ae92abd287c/patchright-1.60.1-py3-none-win_arm64.whl", hash = "sha256:f795728c1e27fc226dbe203c1aec713a537f01be963474fe0f3691f5e6457f9f", size = 34022283, upload-time = "2026-06-03T12:12:26.732Z" },
 ]
 
 [[package]]
@@ -1709,6 +1826,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1743,15 +1872,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
-]
-
-[[package]]
-name = "pysocks"
-version = "1.7.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
 ]
 
 [[package]]
@@ -2206,23 +2326,6 @@ wheels = [
 ]
 
 [[package]]
-name = "selenium"
-version = "4.35.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "trio" },
-    { name = "trio-websocket" },
-    { name = "typing-extensions" },
-    { name = "urllib3", extra = ["socks"] },
-    { name = "websocket-client" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/75/67/9016942b5781843cfea6f5bc1383cea852d9fa08f85f55a0547874525b5c/selenium-4.35.0.tar.gz", hash = "sha256:83937a538afb40ef01e384c1405c0863fa184c26c759d34a1ebbe7b925d3481c", size = 907991, upload-time = "2025-08-12T15:46:40.822Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/ef/d0e033e1b3f19a0325ce03863b68d709780908381135fc0f9436dea76a7b/selenium-4.35.0-py3-none-any.whl", hash = "sha256:90bb6c6091fa55805785cf1660fa1e2176220475ccdb466190f654ef8eef6114", size = 9602106, upload-time = "2025-08-12T15:46:38.244Z" },
-]
-
-[[package]]
 name = "setuptools"
 version = "80.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2333,7 +2436,7 @@ wheels = [
 
 [[package]]
 name = "trio"
-version = "0.30.0"
+version = "0.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -2344,24 +2447,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "sortedcontainers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/c1/68d582b4d3a1c1f8118e18042464bb12a7c1b75d64d75111b297687041e3/trio-0.30.0.tar.gz", hash = "sha256:0781c857c0c81f8f51e0089929a26b5bb63d57f927728a5586f7e36171f064df", size = 593776, upload-time = "2025-04-21T00:48:19.507Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/b6/c744031c6f89b18b3f5f4f7338603ab381d740a7f45938c4607b2302481f/trio-0.33.0.tar.gz", hash = "sha256:a29b92b73f09d4b48ed249acd91073281a7f1063f09caba5dc70465b5c7aa970", size = 605109, upload-time = "2026-02-14T18:40:55.386Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/8e/3f6dfda475ecd940e786defe6df6c500734e686c9cd0a0f8ef6821e9b2f2/trio-0.30.0-py3-none-any.whl", hash = "sha256:3bf4f06b8decf8d3cf00af85f40a89824669e2d033bb32469d34840edcfc22a5", size = 499194, upload-time = "2025-04-21T00:48:17.167Z" },
-]
-
-[[package]]
-name = "trio-websocket"
-version = "0.12.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "outcome" },
-    { name = "trio" },
-    { name = "wsproto" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/3c/8b4358e81f2f2cfe71b66a267f023a91db20a817b9425dd964873796980a/trio_websocket-0.12.2.tar.gz", hash = "sha256:22c72c436f3d1e264d0910a3951934798dcc5b00ae56fc4ee079d46c7cf20fae", size = 33549, upload-time = "2025-02-25T05:16:58.947Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/19/eb640a397bba49ba49ef9dbe2e7e5c04202ba045b6ce2ec36e9cadc51e04/trio_websocket-0.12.2-py3-none-any.whl", hash = "sha256:df605665f1db533f4a386c94525870851096a223adcb97f72a07e8b4beba45b6", size = 21221, upload-time = "2025-02-25T05:16:57.545Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/93/dab25dc87ac48da0fe0f6419e07d0bfd98799bed4e05e7b9e0f85a1a4b4b/trio-0.33.0-py3-none-any.whl", hash = "sha256:3bd5d87f781d9b0192d592aef28691f8951d6c2e41b7e1da4c25cde6c180ae9b", size = 510294, upload-time = "2026-02-14T18:40:53.313Z" },
 ]
 
 [[package]]
@@ -2386,11 +2474,11 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.14.1"
+version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36", size = 107673, upload-time = "2025-07-04T13:28:34.16Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76", size = 43906, upload-time = "2025-07-04T13:28:32.743Z" },
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]
@@ -2406,28 +2494,12 @@ wheels = [
 ]
 
 [[package]]
-name = "undetected-chromedriver"
-version = "3.5.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "requests" },
-    { name = "selenium" },
-    { name = "websockets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/98/7ab46625ce2317756e4e857fe6ac24b6378c3e8f477da26c95226ed8ccb7/undetected-chromedriver-3.5.5.tar.gz", hash = "sha256:9f945e1435005247abe17de316bcfda85b284a4177fd5f25167c78ced33b65ec", size = 65409, upload-time = "2024-02-17T17:18:36.855Z" }
-
-[[package]]
 name = "urllib3"
-version = "2.5.0"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
-]
-
-[package.optional-dependencies]
-socks = [
-    { name = "pysocks" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]
@@ -2492,74 +2564,6 @@ wheels = [
 ]
 
 [[package]]
-name = "websocket-client"
-version = "1.8.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e6/30/fba0d96b4b5fbf5948ed3f4681f7da2f9f64512e1d303f94b4cc174c24a5/websocket_client-1.8.0.tar.gz", hash = "sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da", size = 54648, upload-time = "2024-04-23T22:16:16.976Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/84/44687a29792a70e111c5c477230a72c4b957d88d16141199bf9acb7537a3/websocket_client-1.8.0-py3-none-any.whl", hash = "sha256:17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526", size = 58826, upload-time = "2024-04-23T22:16:14.422Z" },
-]
-
-[[package]]
-name = "websockets"
-version = "15.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/da/6462a9f510c0c49837bbc9345aca92d767a56c1fb2939e1579df1e1cdcf7/websockets-15.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d63efaa0cd96cf0c5fe4d581521d9fa87744540d4bc999ae6e08595a1014b45b", size = 175423, upload-time = "2025-03-05T20:01:35.363Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/9f/9d11c1a4eb046a9e106483b9ff69bce7ac880443f00e5ce64261b47b07e7/websockets-15.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ac60e3b188ec7574cb761b08d50fcedf9d77f1530352db4eef1707fe9dee7205", size = 173080, upload-time = "2025-03-05T20:01:37.304Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/4f/b462242432d93ea45f297b6179c7333dd0402b855a912a04e7fc61c0d71f/websockets-15.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5756779642579d902eed757b21b0164cd6fe338506a8083eb58af5c372e39d9a", size = 173329, upload-time = "2025-03-05T20:01:39.668Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/0c/6afa1f4644d7ed50284ac59cc70ef8abd44ccf7d45850d989ea7310538d0/websockets-15.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fdfe3e2a29e4db3659dbd5bbf04560cea53dd9610273917799f1cde46aa725e", size = 182312, upload-time = "2025-03-05T20:01:41.815Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/d4/ffc8bd1350b229ca7a4db2a3e1c482cf87cea1baccd0ef3e72bc720caeec/websockets-15.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c2529b320eb9e35af0fa3016c187dffb84a3ecc572bcee7c3ce302bfeba52bf", size = 181319, upload-time = "2025-03-05T20:01:43.967Z" },
-    { url = "https://files.pythonhosted.org/packages/97/3a/5323a6bb94917af13bbb34009fac01e55c51dfde354f63692bf2533ffbc2/websockets-15.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac1e5c9054fe23226fb11e05a6e630837f074174c4c2f0fe442996112a6de4fb", size = 181631, upload-time = "2025-03-05T20:01:46.104Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/cc/1aeb0f7cee59ef065724041bb7ed667b6ab1eeffe5141696cccec2687b66/websockets-15.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5df592cd503496351d6dc14f7cdad49f268d8e618f80dce0cd5a36b93c3fc08d", size = 182016, upload-time = "2025-03-05T20:01:47.603Z" },
-    { url = "https://files.pythonhosted.org/packages/79/f9/c86f8f7af208e4161a7f7e02774e9d0a81c632ae76db2ff22549e1718a51/websockets-15.0.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:0a34631031a8f05657e8e90903e656959234f3a04552259458aac0b0f9ae6fd9", size = 181426, upload-time = "2025-03-05T20:01:48.949Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/b9/828b0bc6753db905b91df6ae477c0b14a141090df64fb17f8a9d7e3516cf/websockets-15.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3d00075aa65772e7ce9e990cab3ff1de702aa09be3940d1dc88d5abf1ab8a09c", size = 181360, upload-time = "2025-03-05T20:01:50.938Z" },
-    { url = "https://files.pythonhosted.org/packages/89/fb/250f5533ec468ba6327055b7d98b9df056fb1ce623b8b6aaafb30b55d02e/websockets-15.0.1-cp310-cp310-win32.whl", hash = "sha256:1234d4ef35db82f5446dca8e35a7da7964d02c127b095e172e54397fb6a6c256", size = 176388, upload-time = "2025-03-05T20:01:52.213Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/46/aca7082012768bb98e5608f01658ff3ac8437e563eca41cf068bd5849a5e/websockets-15.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:39c1fec2c11dc8d89bba6b2bf1556af381611a173ac2b511cf7231622058af41", size = 176830, upload-time = "2025-03-05T20:01:53.922Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/32/18fcd5919c293a398db67443acd33fde142f283853076049824fc58e6f75/websockets-15.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:823c248b690b2fd9303ba00c4f66cd5e2d8c3ba4aa968b2779be9532a4dad431", size = 175423, upload-time = "2025-03-05T20:01:56.276Z" },
-    { url = "https://files.pythonhosted.org/packages/76/70/ba1ad96b07869275ef42e2ce21f07a5b0148936688c2baf7e4a1f60d5058/websockets-15.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678999709e68425ae2593acf2e3ebcbcf2e69885a5ee78f9eb80e6e371f1bf57", size = 173082, upload-time = "2025-03-05T20:01:57.563Z" },
-    { url = "https://files.pythonhosted.org/packages/86/f2/10b55821dd40eb696ce4704a87d57774696f9451108cff0d2824c97e0f97/websockets-15.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d50fd1ee42388dcfb2b3676132c78116490976f1300da28eb629272d5d93e905", size = 173330, upload-time = "2025-03-05T20:01:59.063Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/90/1c37ae8b8a113d3daf1065222b6af61cc44102da95388ac0018fcb7d93d9/websockets-15.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d99e5546bf73dbad5bf3547174cd6cb8ba7273062a23808ffea025ecb1cf8562", size = 182878, upload-time = "2025-03-05T20:02:00.305Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/8d/96e8e288b2a41dffafb78e8904ea7367ee4f891dafc2ab8d87e2124cb3d3/websockets-15.0.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66dd88c918e3287efc22409d426c8f729688d89a0c587c88971a0faa2c2f3792", size = 181883, upload-time = "2025-03-05T20:02:03.148Z" },
-    { url = "https://files.pythonhosted.org/packages/93/1f/5d6dbf551766308f6f50f8baf8e9860be6182911e8106da7a7f73785f4c4/websockets-15.0.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8dd8327c795b3e3f219760fa603dcae1dcc148172290a8ab15158cf85a953413", size = 182252, upload-time = "2025-03-05T20:02:05.29Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/78/2d4fed9123e6620cbf1706c0de8a1632e1a28e7774d94346d7de1bba2ca3/websockets-15.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8fdc51055e6ff4adeb88d58a11042ec9a5eae317a0a53d12c062c8a8865909e8", size = 182521, upload-time = "2025-03-05T20:02:07.458Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/3b/66d4c1b444dd1a9823c4a81f50231b921bab54eee2f69e70319b4e21f1ca/websockets-15.0.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:693f0192126df6c2327cce3baa7c06f2a117575e32ab2308f7f8216c29d9e2e3", size = 181958, upload-time = "2025-03-05T20:02:09.842Z" },
-    { url = "https://files.pythonhosted.org/packages/08/ff/e9eed2ee5fed6f76fdd6032ca5cd38c57ca9661430bb3d5fb2872dc8703c/websockets-15.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:54479983bd5fb469c38f2f5c7e3a24f9a4e70594cd68cd1fa6b9340dadaff7cf", size = 181918, upload-time = "2025-03-05T20:02:11.968Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/75/994634a49b7e12532be6a42103597b71098fd25900f7437d6055ed39930a/websockets-15.0.1-cp311-cp311-win32.whl", hash = "sha256:16b6c1b3e57799b9d38427dda63edcbe4926352c47cf88588c0be4ace18dac85", size = 176388, upload-time = "2025-03-05T20:02:13.32Z" },
-    { url = "https://files.pythonhosted.org/packages/98/93/e36c73f78400a65f5e236cd376713c34182e6663f6889cd45a4a04d8f203/websockets-15.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:27ccee0071a0e75d22cb35849b1db43f2ecd3e161041ac1ee9d2352ddf72f065", size = 176828, upload-time = "2025-03-05T20:02:14.585Z" },
-    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437, upload-time = "2025-03-05T20:02:16.706Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096, upload-time = "2025-03-05T20:02:18.832Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332, upload-time = "2025-03-05T20:02:20.187Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152, upload-time = "2025-03-05T20:02:22.286Z" },
-    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096, upload-time = "2025-03-05T20:02:24.368Z" },
-    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523, upload-time = "2025-03-05T20:02:25.669Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790, upload-time = "2025-03-05T20:02:26.99Z" },
-    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165, upload-time = "2025-03-05T20:02:30.291Z" },
-    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160, upload-time = "2025-03-05T20:02:31.634Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395, upload-time = "2025-03-05T20:02:33.017Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841, upload-time = "2025-03-05T20:02:34.498Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440, upload-time = "2025-03-05T20:02:36.695Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098, upload-time = "2025-03-05T20:02:37.985Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329, upload-time = "2025-03-05T20:02:39.298Z" },
-    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111, upload-time = "2025-03-05T20:02:40.595Z" },
-    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054, upload-time = "2025-03-05T20:02:41.926Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496, upload-time = "2025-03-05T20:02:43.304Z" },
-    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829, upload-time = "2025-03-05T20:02:48.812Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217, upload-time = "2025-03-05T20:02:50.14Z" },
-    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload-time = "2025-03-05T20:02:51.561Z" },
-    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
-    { url = "https://files.pythonhosted.org/packages/02/9e/d40f779fa16f74d3468357197af8d6ad07e7c5a27ea1ca74ceb38986f77a/websockets-15.0.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0c9e74d766f2818bb95f84c25be4dea09841ac0f734d1966f415e4edfc4ef1c3", size = 173109, upload-time = "2025-03-05T20:03:17.769Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/cd/5b887b8585a593073fd92f7c23ecd3985cd2c3175025a91b0d69b0551372/websockets-15.0.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:1009ee0c7739c08a0cd59de430d6de452a55e42d6b522de7aa15e6f67db0b8e1", size = 173343, upload-time = "2025-03-05T20:03:19.094Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/ae/d34f7556890341e900a95acf4886833646306269f899d58ad62f588bf410/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76d1f20b1c7a2fa82367e04982e708723ba0e7b8d43aa643d3dcd404d74f1475", size = 174599, upload-time = "2025-03-05T20:03:21.1Z" },
-    { url = "https://files.pythonhosted.org/packages/71/e6/5fd43993a87db364ec60fc1d608273a1a465c0caba69176dd160e197ce42/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f29d80eb9a9263b8d109135351caf568cc3f80b9928bccde535c235de55c22d9", size = 174207, upload-time = "2025-03-05T20:03:23.221Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/fb/c492d6daa5ec067c2988ac80c61359ace5c4c674c532985ac5a123436cec/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04", size = 174155, upload-time = "2025-03-05T20:03:25.321Z" },
-    { url = "https://files.pythonhosted.org/packages/68/a1/dcb68430b1d00b698ae7a7e0194433bce4f07ded185f0ee5fb21e2a2e91e/websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122", size = 176884, upload-time = "2025-03-05T20:03:27.934Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
-]
-
-[[package]]
 name = "werkzeug"
 version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2587,18 +2591,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
-]
-
-[[package]]
-name = "wsproto"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "h11" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/4a/44d3c295350d776427904d73c189e10aeae66d7f555bb2feee16d1e4ba5a/wsproto-1.2.0.tar.gz", hash = "sha256:ad565f26ecb92588a3e43bc3d96164de84cd9902482b130d0ddbaa9664a85065", size = 53425, upload-time = "2022-08-23T19:58:21.447Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/58/e860788190eba3bcce367f74d29c4675466ce8dddfba85f7827588416f01/wsproto-1.2.0-py3-none-any.whl", hash = "sha256:b9acddd652b585d75b20477888c56642fdade28bdfd3579aa24a4d2c037dd736", size = 24226, upload-time = "2022-08-23T19:58:19.96Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
…te browser engine to Patchright

Engine
- Replace Selenium + undetected-chromedriver with Patchright (undetected Playwright): eliminates the chromedriver/Chrome version-matching failure, patches the CDP Runtime.enable leak, async-native. Centralize all DOM selectors in selectors.py (locale-independent, verified live).
- Add a default RPC engine (client_rpc.py) backed by notebooklm-py's batchexecute API. Browser is used only to bootstrap the login session into a Playwright storage_state (auth_bridge.py); all actions go via RPC.
- Select engine via config (engine: "rpc" | "patchright"); RPC is default.

MCP server
- Lazy client init (transport binds without a working browser).
- Add 9 management tools: list/create/rename/delete notebooks, get_notebook_summary, list/add-url/add-text/delete sources (RPC engine).

Quality / ops
- Single-source __version__; fix Dockerfile (drop dead chromedriver endpoint, HTTP transport for detached) and docker-compose.
- Rewrite the entire test suite off Selenium onto faithful async fakes; add a gated real-browser integration tier. 293 tests, ~98% coverage, mutation- tested. ruff/black/mypy clean.