### PR TITLE
Flatten MCP tool params; drop request models and dead code

### DIFF
--- a/src/notebooklm_mcp/client_rpc.py
+++ b/src/notebooklm_mcp/client_rpc.py
@@ -55,10 +55,6 @@ def _source_dict(src: Any) -> Dict[str, Any]:
 class NotebookLMRPCClient:
     """High-level RPC client (notebooklm-py backend) with management support."""
 
-    #: Marks this engine as capable of notebook/source management so the server
-    #: can expose those tools (the browser engine sets this False).
-    supports_management = True
-
     def __init__(self, config: ServerConfig):
         self.config = config
         self.current_notebook_id: Optional[str] = config.default_notebook_id
@@ -153,11 +149,8 @@ class NotebookLMRPCClient:
             raise ChatError(f"RPC chat failed: {exc}") from exc
         self._last_answer = getattr(result, "answer", str(result))
 
-    async def get_response(
-        self, wait_for_completion: bool = True, max_wait: Optional[int] = None
-    ) -> str:
-        # ``chat.ask`` already returns the completed answer, so the stored
-        # answer is final; the wait args are accepted for interface parity.
+    async def get_response(self) -> str:
+        # ``chat.ask`` already returns the completed answer in send_message.
         return self._last_answer or "No response content found"
 
     async def navigate_to_notebook(self, notebook_id: str) -> str:

--- a/src/notebooklm_mcp/server.py
+++ b/src/notebooklm_mcp/server.py
@@ -10,7 +10,6 @@ from typing import Any, Awaitable, Callable, Dict, Optional, TypeVar
 
 from fastmcp import FastMCP
 from loguru import logger
-from pydantic import BaseModel, Field
 
 from .client_rpc import NotebookLMRPCClient
 from .config import ServerConfig
@@ -46,95 +45,14 @@ def _tool(
     return decorator
 
 
-# Pydantic models for type-safe tool parameters
-class SendMessageRequest(BaseModel):
-    """Request model for sending a message to NotebookLM"""
-
-    message: str = Field(..., description="The message to send to NotebookLM")
-    wait_for_response: bool = Field(
-        True, description="Whether to wait for response after sending"
-    )
-
-
-class GetResponseRequest(BaseModel):
-    """Request model for getting response from NotebookLM"""
-
-
-class ChatRequest(BaseModel):
-    """Request model for complete chat interaction"""
-
-    message: str = Field(..., description="The message to send")
-    notebook_id: Optional[str] = Field(
-        None, description="Optional notebook ID to switch to"
-    )
-
-
-class NavigateRequest(BaseModel):
-    """Request model for navigating to a notebook"""
-
-    notebook_id: str = Field(..., description="The notebook ID to navigate to")
-
-
-class SetNotebookRequest(BaseModel):
-    """Request model for setting default notebook"""
-
-    notebook_id: str = Field(..., description="The notebook ID to set as default")
-
-
-class CreateNotebookRequest(BaseModel):
-    """Request model for creating a notebook"""
-
-    title: str = Field(..., description="Title for the new notebook")
-
-
-class RenameNotebookRequest(BaseModel):
-    """Request model for renaming a notebook"""
-
-    notebook_id: str = Field(..., description="The notebook ID to rename")
-    new_title: str = Field(..., description="The new title")
-
-
-class NotebookIdRequest(BaseModel):
-    """Request model for operations that take only a notebook ID"""
-
-    notebook_id: str = Field(..., description="The notebook ID")
-
-
-class AddSourceUrlRequest(BaseModel):
-    """Request model for adding a URL source"""
-
-    notebook_id: str = Field(..., description="The notebook ID")
-    url: str = Field(..., description="Web URL or YouTube link to add as a source")
-
-
-class AddSourceTextRequest(BaseModel):
-    """Request model for adding a text source"""
-
-    notebook_id: str = Field(..., description="The notebook ID")
-    title: str = Field(..., description="Title for the text source")
-    text: str = Field(..., description="The raw text content")
-
-
-class DeleteSourceRequest(BaseModel):
-    """Request model for deleting a source"""
-
-    notebook_id: str = Field(..., description="The notebook ID")
-    source_id: str = Field(..., description="The source ID to delete")
-
-
 class NotebookLMFastMCP:
     """FastMCP v2 server for NotebookLM automation with enhanced error handling"""
 
     def __init__(self, config: ServerConfig):
         self.config = config
         self.client: Optional[NotebookLMRPCClient] = None
-
-        # Initialize FastMCP application
         self.app = FastMCP(name="NotebookLM MCP Server v2")
-
-        # Setup tools
         self._setup_tools()
-
         logger.info(
             f"FastMCP v2 server initialized for notebook: {config.default_notebook_id}"
         )
@@ -161,102 +79,86 @@ class NotebookLMFastMCP:
             raise NotebookLMError(f"Client initialization failed: {e}")
 
     def _setup_tools(self) -> None:
-        """Setup FastMCP v2 tools with enhanced error handling and performance"""
+        """Register the FastMCP tools. Parameters are plain typed arguments, so
+        FastMCP generates a flat input schema for each tool."""
 
+        # ------------------------------------------------------------------ #
+        # Chat
+        # ------------------------------------------------------------------ #
         @self.app.tool()
         async def healthcheck() -> Dict[str, Any]:
             """Check if the NotebookLM server is healthy and responsive."""
-            try:
-                if not self.client:
-                    return {
-                        "status": "unhealthy",
-                        "message": "Client not initialized",
-                        "authenticated": False,
-                    }
-
-                auth_status = getattr(self.client, "_is_authenticated", False)
-
+            if self.client is None:
                 return {
-                    "status": "healthy" if auth_status else "needs_auth",
-                    "message": "Server is running",
-                    "authenticated": auth_status,
-                    "notebook_id": self.config.default_notebook_id,
-                    "mode": "headless" if self.config.headless else "gui",
-                }
-
-            except Exception as e:
-                logger.error(f"Health check failed: {e}")
-                return {
-                    "status": "error",
-                    "message": f"Health check failed: {e}",
+                    "status": "unhealthy",
+                    "message": "Client not initialized",
                     "authenticated": False,
                 }
+            authed = self.client.is_authenticated
+            return {
+                "status": "healthy" if authed else "needs_auth",
+                "message": "Server is running",
+                "authenticated": authed,
+                "notebook_id": self.config.default_notebook_id,
+                "mode": "headless" if self.config.headless else "gui",
+            }
 
         @self.app.tool()
         @_tool("Failed to send message")
-        async def send_chat_message(request: SendMessageRequest) -> Dict[str, Any]:
+        async def send_chat_message(
+            message: str, wait_for_response: bool = True
+        ) -> Dict[str, Any]:
             """Send a message to NotebookLM chat interface."""
             client = await self._ensure_client()
-            await client.send_message(request.message)
-
-            response_data = {"status": "sent", "message": request.message}
-
-            if request.wait_for_response:
-                response = await client.get_response()
-                response_data["response"] = response
-                response_data["status"] = "completed"
-
-            logger.info(f"Message sent successfully: {request.message[:50]}...")
-            return response_data
+            await client.send_message(message)
+            data: Dict[str, Any] = {"status": "sent", "message": message}
+            if wait_for_response:
+                data["response"] = await client.get_response()
+                data["status"] = "completed"
+            logger.info(f"Message sent: {message[:50]}...")
+            return data
 
         @self.app.tool()
         @_tool("Failed to get response")
-        async def get_chat_response(request: GetResponseRequest) -> Dict[str, Any]:
-            """Get the latest response from NotebookLM with streaming support."""
+        async def get_chat_response() -> Dict[str, Any]:
+            """Get the latest response from NotebookLM."""
             client = await self._ensure_client()
-            response = await client.get_response()
-
-            logger.info("Response retrieved successfully")
             return {
                 "status": "success",
-                "response": response,
+                "response": await client.get_response(),
                 "message": "Response retrieved successfully",
             }
 
         @self.app.tool()
         @_tool("Chat interaction failed")
-        async def chat_with_notebook(request: ChatRequest) -> Dict[str, Any]:
+        async def chat_with_notebook(
+            message: str, notebook_id: Optional[str] = None
+        ) -> Dict[str, Any]:
             """Complete chat interaction: send message and get response."""
             client = await self._ensure_client()
-
-            # Switch notebook if specified
-            if request.notebook_id:
-                await client.navigate_to_notebook(request.notebook_id)
-
-            # Send message and get response
-            await client.send_message(request.message)
+            if notebook_id:
+                await client.navigate_to_notebook(notebook_id)
+            await client.send_message(message)
             response = await client.get_response()
-
-            logger.info(f"Chat completed: {request.message[:50]}...")
+            logger.info(f"Chat completed: {message[:50]}...")
             return {
                 "status": "success",
-                "message": request.message,
+                "message": message,
                 "response": response,
-                "notebook_id": request.notebook_id or self.config.default_notebook_id,
+                "notebook_id": notebook_id or self.config.default_notebook_id,
             }
 
         @self.app.tool()
         @_tool("Failed to navigate to notebook")
-        async def navigate_to_notebook(request: NavigateRequest) -> Dict[str, Any]:
+        async def navigate_to_notebook(notebook_id: str) -> Dict[str, Any]:
             """Navigate to a specific notebook."""
             client = await self._ensure_client()
-            await client.navigate_to_notebook(request.notebook_id)
-
-            logger.info(f"Navigated to notebook: {request.notebook_id}")
+            await client.navigate_to_notebook(notebook_id)
+            logger.info(f"Navigated to notebook: {notebook_id}")
             return {
                 "status": "success",
-                "notebook_id": request.notebook_id,
-                "message": f"Successfully navigated to notebook {request.notebook_id}",
+                "notebook_id": notebook_id,
+                "message": f"Successfully navigated to notebook {notebook_id}",
             }
 
         @self.app.tool()
@@ -270,19 +172,16 @@ class NotebookLMFastMCP:
 
         @self.app.tool()
         @_tool("Failed to set default notebook")
-        async def set_default_notebook(request: SetNotebookRequest) -> Dict[str, Any]:
+        async def set_default_notebook(notebook_id: str) -> Dict[str, Any]:
             """Set the default notebook ID."""
             old_notebook = self.config.default_notebook_id
-            self.config.default_notebook_id = request.notebook_id
-
-            logger.info(
-                f"Default notebook changed: {old_notebook} → {request.notebook_id}"
-            )
+            self.config.default_notebook_id = notebook_id
+            logger.info(f"Default notebook changed: {old_notebook} → {notebook_id}")
             return {
                 "status": "success",
                 "old_notebook_id": old_notebook,
-                "new_notebook_id": request.notebook_id,
-                "message": f"Default notebook set to {request.notebook_id}",
+                "new_notebook_id": notebook_id,
+                "message": f"Default notebook set to {notebook_id}",
             }
 
         # ------------------------------------------------------------------ #
@@ -302,91 +201,85 @@ class NotebookLMFastMCP:
 
         @self.app.tool()
         @_tool("Failed to create notebook")
-        async def create_notebook(request: CreateNotebookRequest) -> Dict[str, Any]:
+        async def create_notebook(title: str) -> Dict[str, Any]:
             """Create a new notebook with the given title."""
             client = await self._ensure_client()
-            notebook = await client.create_notebook(request.title)
-            return {"status": "success", "notebook": notebook}
+            return {
+                "status": "success",
+                "notebook": await client.create_notebook(title),
+            }
 
         @self.app.tool()
         @_tool("Failed to rename notebook")
-        async def rename_notebook(request: RenameNotebookRequest) -> Dict[str, Any]:
+        async def rename_notebook(notebook_id: str, new_title: str) -> Dict[str, Any]:
             """Rename a notebook."""
             client = await self._ensure_client()
-            notebook = await client.rename_notebook(
-                request.notebook_id, request.new_title
-            )
+            notebook = await client.rename_notebook(notebook_id, new_title)
             return {"status": "success", "notebook": notebook}
 
         @self.app.tool()
         @_tool("Failed to delete notebook")
-        async def delete_notebook(request: NotebookIdRequest) -> Dict[str, Any]:
+        async def delete_notebook(notebook_id: str) -> Dict[str, Any]:
             """Delete a notebook by ID."""
             client = await self._ensure_client()
-            await client.delete_notebook(request.notebook_id)
-            return {"status": "success", "notebook_id": request.notebook_id}
+            await client.delete_notebook(notebook_id)
+            return {"status": "success", "notebook_id": notebook_id}
 
         @self.app.tool()
         @_tool("Failed to get notebook summary")
-        async def get_notebook_summary(request: NotebookIdRequest) -> Dict[str, Any]:
+        async def get_notebook_summary(notebook_id: str) -> Dict[str, Any]:
             """Get the AI summary of a notebook."""
             client = await self._ensure_client()
-            summary = await client.get_notebook_summary(request.notebook_id)
+            summary = await client.get_notebook_summary(notebook_id)
             return {"status": "success", "summary": summary}
 
         @self.app.tool()
         @_tool("Failed to list sources")
-        async def list_sources(request: NotebookIdRequest) -> Dict[str, Any]:
+        async def list_sources(notebook_id: str) -> Dict[str, Any]:
             """List the sources in a notebook."""
             client = await self._ensure_client()
-            sources = await client.list_sources(request.notebook_id)
-            return {
-                "status": "success",
-                "count": len(sources),
-                "sources": sources,
-            }
+            sources = await client.list_sources(notebook_id)
+            return {"status": "success", "count": len(sources), "sources": sources}
 
         @self.app.tool()
         @_tool("Failed to add URL source")
-        async def add_source_url(request: AddSourceUrlRequest) -> Dict[str, Any]:
+        async def add_source_url(notebook_id: str, url: str) -> Dict[str, Any]:
             """Add a web URL (or YouTube link) as a source to a notebook."""
             client = await self._ensure_client()
-            source = await client.add_source_url(request.notebook_id, request.url)
+            source = await client.add_source_url(notebook_id, url)
             return {"status": "success", "source": source}
 
         @self.app.tool()
         @_tool("Failed to add text source")
-        async def add_source_text(request: AddSourceTextRequest) -> Dict[str, Any]:
+        async def add_source_text(
+            notebook_id: str, title: str, text: str
+        ) -> Dict[str, Any]:
             """Add raw text as a source to a notebook."""
             client = await self._ensure_client()
-            source = await client.add_source_text(
-                request.notebook_id, request.title, request.text
-            )
+            source = await client.add_source_text(notebook_id, title, text)
             return {"status": "success", "source": source}
 
         @self.app.tool()
         @_tool("Failed to delete source")
-        async def delete_source(request: DeleteSourceRequest) -> Dict[str, Any]:
+        async def delete_source(notebook_id: str, source_id: str) -> Dict[str, Any]:
             """Delete a source from a notebook."""
             client = await self._ensure_client()
-            await client.delete_source(request.notebook_id, request.source_id)
+            await client.delete_source(notebook_id, source_id)
             return {
                 "status": "success",
-                "notebook_id": request.notebook_id,
-                "source_id": request.source_id,
+                "notebook_id": notebook_id,
+                "source_id": source_id,
             }
 
     async def start(
         self, transport: str = "stdio", host: str = "127.0.0.1", port: int = 8000
     ) -> None:
-        """Start the FastMCP v2 server with specified transport.
+        """Start the FastMCP v2 server with the given transport.
 
-        The browser client is initialized lazily on first tool use (see
-        ``_ensure_client``), so the transport binds without requiring a working
-        browser up front.
+        The client is initialized lazily on first tool use (see
+        ``_ensure_client``), so the transport binds without requiring a session.
         """
         try:
-            # Run the FastMCP server with specified transport
             if transport == "http":
                 logger.info(f"🌐 Starting HTTP server on http://{host}:{port}/mcp/")
                 await self.app.run_async(transport="http", host=host, port=port)
@@ -396,7 +289,6 @@ class NotebookLMFastMCP:
             else:
                 logger.info("📡 Starting STDIO server...")
                 await self.app.run_async(transport="stdio")
-
         except Exception as e:
             logger.error(f"Failed to start FastMCP server: {e}")
             raise NotebookLMError(f"Server startup failed: {e}")
@@ -411,27 +303,22 @@ class NotebookLMFastMCP:
             logger.error(f"Error during server shutdown: {e}")
 
 
-# Factory function for easy server creation
 def create_fastmcp_server(config_file: str) -> NotebookLMFastMCP:
-    """Create a FastMCP v2 server from configuration file"""
+    """Create a FastMCP v2 server from a configuration file."""
     from .config import load_config
 
-    config = load_config(config_file)
-    return NotebookLMFastMCP(config)
+    return NotebookLMFastMCP(load_config(config_file))
 
 
-# Main entry point for standalone usage
 async def main() -> None:
-    """Main entry point for running server standalone"""
+    """Main entry point for running the server standalone."""
     import sys
 
     if len(sys.argv) < 2:
         print("Usage: python -m notebooklm_mcp.server <config_file>")
         sys.exit(1)
 
-    config_file = sys.argv[1]
-    server = create_fastmcp_server(config_file)
-
+    server = create_fastmcp_server(sys.argv[1])
     try:
         await server.start()
     except KeyboardInterrupt:

--- a/tests/test_client_rpc.py
+++ b/tests/test_client_rpc.py
@@ -259,12 +259,8 @@ def test_source_dict_tolerates_missing_attrs():
 
 
 # --------------------------------------------------------------------------- #
-# Engine flags / trivial properties
+# Trivial properties
 # --------------------------------------------------------------------------- #
-def test_supports_management_is_true():
-    assert NotebookLMRPCClient.supports_management is True
-
-
 def test_default_notebook_seeded_and_unauthenticated():
     cfg = ServerConfig(default_notebook_id="seed")
     client = NotebookLMRPCClient(cfg)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -47,6 +47,10 @@ class DummyClient:
         self.call_order: list[str] = []
         self.get_response_calls = 0
 
+    @property
+    def is_authenticated(self):
+        return self._is_authenticated
+
     async def start(self):
         self.started = True
 
@@ -75,6 +79,22 @@ class DummyClient:
 @pytest.fixture(autouse=True)
 def patch_fastmcp(monkeypatch):
     monkeypatch.setattr(server_module, "FastMCP", DummyFastMCP)
+
+
+def _server_with_client(monkeypatch, client_cls=DummyClient):
+    """Build a server with ``client_cls`` wired in and ``_ensure_client``
+    stubbed to return it (no real initialization)."""
+    monkeypatch.setattr(server_module, "NotebookLMRPCClient", DummyClient)
+    config = ServerConfig(default_notebook_id="abc")
+    server = server_module.NotebookLMFastMCP(config)
+    client = client_cls(config)
+    server.client = client
+
+    async def fake_ensure(self):
+        return self.client
+
+    server._ensure_client = MethodType(fake_ensure, server)
+    return server, client
 
 
 def test_notebooklmfastmcp_registers_tools(monkeypatch):
@@ -149,11 +169,11 @@ async def test_start_uses_transport(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_start_does_not_init_browser_eagerly(monkeypatch):
-    """Lazy init: a broken browser client must NOT stop the transport binding.
+async def test_start_does_not_init_client_eagerly(monkeypatch):
+    """Lazy init: a broken client must NOT stop the transport binding.
 
-    ``start()`` no longer calls ``_ensure_client`` — the browser is created on
-    the first tool call — so even a client whose ``start()`` explodes leaves the
+    ``start()`` does not call ``_ensure_client`` — the client is created on the
+    first tool call — so even a client whose ``start()`` explodes leaves the
     transport free to bind.
     """
 
@@ -164,7 +184,7 @@ async def test_start_does_not_init_browser_eagerly(monkeypatch):
     monkeypatch.setattr(server_module, "NotebookLMRPCClient", ExplodingClient)
     server = server_module.NotebookLMFastMCP(ServerConfig(default_notebook_id="abc"))
 
-    # Should NOT raise: the transport binds without touching the browser.
+    # Should NOT raise: the transport binds without touching the client.
     await server.start()
 
     assert server.app.run_calls[-1] == {"transport": "stdio"}
@@ -174,7 +194,7 @@ async def test_start_does_not_init_browser_eagerly(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_start_handles_transport_errors(monkeypatch):
-    """The ``start()`` error path now fires when the transport itself fails."""
+    """The ``start()`` error path fires when the transport itself fails."""
     monkeypatch.setattr(server_module, "NotebookLMRPCClient", DummyClient)
     server = server_module.NotebookLMFastMCP(ServerConfig(default_notebook_id="abc"))
 
@@ -229,17 +249,10 @@ async def test_healthcheck_tool_reports_status(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_send_chat_message_tool(monkeypatch):
-    monkeypatch.setattr(server_module, "NotebookLMRPCClient", DummyClient)
-    server = server_module.NotebookLMFastMCP(ServerConfig(default_notebook_id="abc"))
-    dummy = DummyClient(server.config)
-    server.client = dummy
-
-    async def fake_ensure(self):
-        return self.client
-
-    server._ensure_client = MethodType(fake_ensure, server)
-    request = server_module.SendMessageRequest(message="hi", wait_for_response=True)
-    response = await server.app.tools["send_chat_message"](request)
+    server, dummy = _server_with_client(monkeypatch)
+    response = await server.app.tools["send_chat_message"](
+        message="hi", wait_for_response=True
+    )
 
     assert dummy.sent_messages == ["hi"]
     assert response["status"] == "completed"
@@ -255,17 +268,10 @@ async def test_send_chat_message_tool(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_send_chat_message_tool_no_wait(monkeypatch):
-    monkeypatch.setattr(server_module, "NotebookLMRPCClient", DummyClient)
-    server = server_module.NotebookLMFastMCP(ServerConfig(default_notebook_id="abc"))
-    dummy = DummyClient(server.config)
-    server.client = dummy
-
-    async def fake_ensure(self):
-        return self.client
-
-    server._ensure_client = MethodType(fake_ensure, server)
-    request = server_module.SendMessageRequest(message="hi", wait_for_response=False)
-    response = await server.app.tools["send_chat_message"](request)
+    server, dummy = _server_with_client(monkeypatch)
+    response = await server.app.tools["send_chat_message"](
+        message="hi", wait_for_response=False
+    )
 
     assert response["status"] == "sent"
     assert "response" not in response
@@ -282,33 +288,20 @@ async def test_send_chat_message_tool_error(monkeypatch):
         async def send_message(self, message):
             raise RuntimeError("fail")
 
-    monkeypatch.setattr(server_module, "NotebookLMRPCClient", DummyClient)
-    server = server_module.NotebookLMFastMCP(ServerConfig(default_notebook_id="abc"))
-    server.client = FailingClient(server.config)
-
-    async def fake_ensure(self):
-        return self.client
-
-    server._ensure_client = MethodType(fake_ensure, server)
-    request = server_module.SendMessageRequest(message="hi", wait_for_response=False)
+    server, _ = _server_with_client(monkeypatch, client_cls=FailingClient)
 
     with pytest.raises(NotebookLMError):
-        await server.app.tools["send_chat_message"](request)
+        await server.app.tools["send_chat_message"](
+            message="hi", wait_for_response=False
+        )
 
 
 @pytest.mark.asyncio
 async def test_chat_with_notebook_tool(monkeypatch):
-    monkeypatch.setattr(server_module, "NotebookLMRPCClient", DummyClient)
-    server = server_module.NotebookLMFastMCP(ServerConfig(default_notebook_id="abc"))
-    dummy = DummyClient(server.config)
-    server.client = dummy
-
-    async def fake_ensure(self):
-        return self.client
-
-    server._ensure_client = MethodType(fake_ensure, server)
-    request = server_module.ChatRequest(message="hello", notebook_id="xyz")
-    response = await server.app.tools["chat_with_notebook"](request)
+    server, dummy = _server_with_client(monkeypatch)
+    response = await server.app.tools["chat_with_notebook"](
+        message="hello", notebook_id="xyz"
+    )
 
     assert dummy.sent_messages == ["hello"]
     assert dummy.navigated_to == ["xyz"]
@@ -324,17 +317,10 @@ async def test_chat_with_notebook_tool(monkeypatch):
 async def test_chat_with_notebook_no_navigation_when_id_absent(monkeypatch):
     """When no notebook_id is supplied the server must skip navigation and
     fall back to the configured default notebook id in its response."""
-    monkeypatch.setattr(server_module, "NotebookLMRPCClient", DummyClient)
-    server = server_module.NotebookLMFastMCP(ServerConfig(default_notebook_id="abc"))
-    dummy = DummyClient(server.config)
-    server.client = dummy
-
-    async def fake_ensure(self):
-        return self.client
-
-    server._ensure_client = MethodType(fake_ensure, server)
-    request = server_module.ChatRequest(message="hello", notebook_id=None)
-    response = await server.app.tools["chat_with_notebook"](request)
+    server, dummy = _server_with_client(monkeypatch)
+    response = await server.app.tools["chat_with_notebook"](
+        message="hello", notebook_id=None
+    )
 
     # No navigation happened; only send + read.
     assert dummy.navigated_to == []
@@ -346,18 +332,8 @@ async def test_chat_with_notebook_no_navigation_when_id_absent(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_get_chat_response(monkeypatch):
-    monkeypatch.setattr(server_module, "NotebookLMRPCClient", DummyClient)
-    server = server_module.NotebookLMFastMCP(ServerConfig(default_notebook_id="abc"))
-    dummy = DummyClient(server.config)
-    server.client = dummy
-
-    async def fake_ensure(self):
-        return self.client
-
-    server._ensure_client = MethodType(fake_ensure, server)
-    request = server_module.GetResponseRequest()
-
-    chat_result = await server.app.tools["get_chat_response"](request)
+    server, dummy = _server_with_client(monkeypatch)
+    chat_result = await server.app.tools["get_chat_response"]()
 
     # Assert on the unique sentinel: this proves the server surfaces the
     # client's actual return value (not a hardcoded "response" string) and
@@ -373,37 +349,20 @@ async def test_get_chat_response_error(monkeypatch):
         async def get_response(self):
             raise RuntimeError("boom")
 
-    monkeypatch.setattr(server_module, "NotebookLMRPCClient", DummyClient)
-    server = server_module.NotebookLMFastMCP(ServerConfig(default_notebook_id="abc"))
-    server.client = FailingClient(server.config)
-
-    async def fake_ensure(self):
-        return self.client
-
-    server._ensure_client = MethodType(fake_ensure, server)
-    request = server_module.GetResponseRequest()
+    server, _ = _server_with_client(monkeypatch, client_cls=FailingClient)
 
     with pytest.raises(NotebookLMError):
-        await server.app.tools["get_chat_response"](request)
+        await server.app.tools["get_chat_response"]()
 
 
 @pytest.mark.asyncio
 async def test_get_and_set_default_notebook_tools(monkeypatch):
-    monkeypatch.setattr(server_module, "NotebookLMRPCClient", DummyClient)
-    server = server_module.NotebookLMFastMCP(ServerConfig(default_notebook_id="abc"))
-    dummy = DummyClient(server.config)
-    server.client = dummy
-
-    async def fake_ensure(self):
-        return self.client
-
-    server._ensure_client = MethodType(fake_ensure, server)
+    server, _ = _server_with_client(monkeypatch)
 
     get_result = await server.app.tools["get_default_notebook"]()
     assert get_result["notebook_id"] == "abc"
 
-    request = server_module.SetNotebookRequest(notebook_id="new-id")
-    set_result = await server.app.tools["set_default_notebook"](request)
+    set_result = await server.app.tools["set_default_notebook"](notebook_id="new-id")
     assert set_result["new_notebook_id"] == "new-id"
     # The old id must be captured BEFORE the swap, proving the server records
     # the transition rather than echoing the new value twice.
@@ -413,25 +372,16 @@ async def test_get_and_set_default_notebook_tools(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_chat_with_notebook_tool_error_wraps_exception(monkeypatch):
-    """A failure inside chat_with_notebook must be wrapped as NotebookLMError
-    (covers the error path, server.py 205-207)."""
+    """A failure inside chat_with_notebook must be wrapped as NotebookLMError."""
 
     class BadClient(DummyClient):
         async def send_message(self, message):
             raise RuntimeError("send blew up")
 
-    monkeypatch.setattr(server_module, "NotebookLMRPCClient", DummyClient)
-    server = server_module.NotebookLMFastMCP(ServerConfig(default_notebook_id="abc"))
-    server.client = BadClient(server.config)
-
-    async def fake_ensure(self):
-        return self.client
-
-    server._ensure_client = MethodType(fake_ensure, server)
-    request = server_module.ChatRequest(message="hello", notebook_id=None)
+    server, _ = _server_with_client(monkeypatch, client_cls=BadClient)
 
     with pytest.raises(NotebookLMError, match="Chat interaction failed"):
-        await server.app.tools["chat_with_notebook"](request)
+        await server.app.tools["chat_with_notebook"](message="hello", notebook_id=None)
 
 
 @pytest.mark.asyncio
@@ -440,18 +390,10 @@ async def test_navigate_to_notebook_tool_error(monkeypatch):
         async def navigate_to_notebook(self, notebook_id):
             raise RuntimeError("navigate-fail")
 
-    monkeypatch.setattr(server_module, "NotebookLMRPCClient", DummyClient)
-    server = server_module.NotebookLMFastMCP(ServerConfig(default_notebook_id="abc"))
-    server.client = BadClient(server.config)
-
-    async def fake_ensure(self):
-        return self.client
-
-    server._ensure_client = MethodType(fake_ensure, server)
-    request = server_module.NavigateRequest(notebook_id="xyz")
+    server, _ = _server_with_client(monkeypatch, client_cls=BadClient)
 
     with pytest.raises(NotebookLMError):
-        await server.app.tools["navigate_to_notebook"](request)
+        await server.app.tools["navigate_to_notebook"](notebook_id="xyz")
 
 
 @pytest.mark.asyncio
@@ -487,33 +429,9 @@ def test_create_fastmcp_server_loads_config(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_healthcheck_tool_error(monkeypatch):
-    monkeypatch.setattr(server_module, "NotebookLMRPCClient", DummyClient)
-    server = server_module.NotebookLMFastMCP(ServerConfig(default_notebook_id="abc"))
-
-    class ExplodingClient:
-        def __getattr__(self, _name):
-            raise RuntimeError("boom")
-
-    server.client = ExplodingClient()
-
-    result = await server.app.tools["healthcheck"]()
-    assert result["status"] == "error"
-
-
-@pytest.mark.asyncio
 async def test_navigate_to_notebook_tool_success(monkeypatch):
-    monkeypatch.setattr(server_module, "NotebookLMRPCClient", DummyClient)
-    server = server_module.NotebookLMFastMCP(ServerConfig(default_notebook_id="abc"))
-    dummy = DummyClient(server.config)
-    server.client = dummy
-
-    async def fake_ensure(self):
-        return self.client
-
-    server._ensure_client = MethodType(fake_ensure, server)
-    request = server_module.NavigateRequest(notebook_id="xyz")
-    result = await server.app.tools["navigate_to_notebook"](request)
+    server, dummy = _server_with_client(monkeypatch)
+    result = await server.app.tools["navigate_to_notebook"](notebook_id="xyz")
 
     assert result["status"] == "success"
     assert dummy.navigated_to == ["xyz"]
@@ -531,10 +449,9 @@ async def test_set_default_notebook_error(monkeypatch):
             super().__setattr__(name, value)
 
     server.config = ExplodingConfig(default_notebook_id="abc")
-    request = server_module.SetNotebookRequest(notebook_id="boom")
 
     with pytest.raises(NotebookLMError):
-        await server.app.tools["set_default_notebook"](request)
+        await server.app.tools["set_default_notebook"](notebook_id="boom")
 
 
 @pytest.mark.asyncio
@@ -628,7 +545,7 @@ async def test_main_handles_general_exception(monkeypatch):
 
 
 # --------------------------------------------------------------------------- #
-# Notebook / source management tools (RPC engine) + the management guard.
+# Notebook / source management tools (RPC engine).
 # --------------------------------------------------------------------------- #
 # Unique sentinels so the management-tool assertions test real wiring (the
 # server surfacing the client's value) rather than echoing a hardcoded payload.
@@ -640,9 +557,7 @@ SUMMARY = "an-ai-generated-summary-3b8f"
 
 
 class ManagementClient(DummyClient):
-    """An RPC-style client that supports management. Records every call."""
-
-    supports_management = True
+    """An RPC-style client with management methods. Records every call."""
 
     def __init__(self, config):
         super().__init__(config)
@@ -683,22 +598,6 @@ class ManagementClient(DummyClient):
         self.management_calls.append(("delete_source", notebook_id, source_id))
 
 
-def _management_server(monkeypatch, client_cls=ManagementClient):
-    """A server with a management-capable client wired in, with
-    ``_ensure_client`` stubbed to that client (no real init)."""
-    monkeypatch.setattr(server_module, "NotebookLMRPCClient", DummyClient)
-    config = ServerConfig(default_notebook_id="abc")
-    server = server_module.NotebookLMFastMCP(config)
-    client = client_cls(config)
-    server.client = client
-
-    async def fake_ensure(self):
-        return self.client
-
-    server._ensure_client = MethodType(fake_ensure, server)
-    return server, client
-
-
 def test_management_tools_registered(monkeypatch):
     """All 9 management tools must be registered on the app."""
     monkeypatch.setattr(server_module, "NotebookLMRPCClient", DummyClient)
@@ -719,7 +618,7 @@ def test_management_tools_registered(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_list_notebooks_tool(monkeypatch):
-    server, client = _management_server(monkeypatch)
+    server, client = _server_with_client(monkeypatch, client_cls=ManagementClient)
     result = await server.app.tools["list_notebooks"]()
     assert result["status"] == "success"
     assert result["count"] == 1
@@ -730,9 +629,8 @@ async def test_list_notebooks_tool(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_create_notebook_tool(monkeypatch):
-    server, client = _management_server(monkeypatch)
-    request = server_module.CreateNotebookRequest(title="My NB")
-    result = await server.app.tools["create_notebook"](request)
+    server, client = _server_with_client(monkeypatch, client_cls=ManagementClient)
+    result = await server.app.tools["create_notebook"](title="My NB")
     assert result["status"] == "success"
     assert result["notebook"] == NB_OBJ
     # The title flowed through to the client unchanged.
@@ -741,20 +639,18 @@ async def test_create_notebook_tool(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_rename_notebook_tool(monkeypatch):
-    server, client = _management_server(monkeypatch)
-    request = server_module.RenameNotebookRequest(
+    server, client = _server_with_client(monkeypatch, client_cls=ManagementClient)
+    result = await server.app.tools["rename_notebook"](
         notebook_id="nb1", new_title="Renamed"
     )
-    result = await server.app.tools["rename_notebook"](request)
     assert result["notebook"] == NB_OBJ
     assert client.management_calls == [("rename_notebook", "nb1", "Renamed")]
 
 
 @pytest.mark.asyncio
 async def test_delete_notebook_tool(monkeypatch):
-    server, client = _management_server(monkeypatch)
-    request = server_module.NotebookIdRequest(notebook_id="nb1")
-    result = await server.app.tools["delete_notebook"](request)
+    server, client = _server_with_client(monkeypatch, client_cls=ManagementClient)
+    result = await server.app.tools["delete_notebook"](notebook_id="nb1")
     assert result["status"] == "success"
     assert result["notebook_id"] == "nb1"
     assert client.management_calls == [("delete_notebook", "nb1")]
@@ -762,9 +658,8 @@ async def test_delete_notebook_tool(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_get_notebook_summary_tool(monkeypatch):
-    server, client = _management_server(monkeypatch)
-    request = server_module.NotebookIdRequest(notebook_id="nb1")
-    result = await server.app.tools["get_notebook_summary"](request)
+    server, client = _server_with_client(monkeypatch, client_cls=ManagementClient)
+    result = await server.app.tools["get_notebook_summary"](notebook_id="nb1")
     # Surfaces the client's unique summary string.
     assert result["summary"] == SUMMARY
     assert client.management_calls == [("get_notebook_summary", "nb1")]
@@ -772,9 +667,8 @@ async def test_get_notebook_summary_tool(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_list_sources_tool(monkeypatch):
-    server, client = _management_server(monkeypatch)
-    request = server_module.NotebookIdRequest(notebook_id="nb1")
-    result = await server.app.tools["list_sources"](request)
+    server, client = _server_with_client(monkeypatch, client_cls=ManagementClient)
+    result = await server.app.tools["list_sources"](notebook_id="nb1")
     assert result["count"] == 1
     assert result["sources"] == SRC_LIST
     assert client.management_calls == [("list_sources", "nb1")]
@@ -782,31 +676,28 @@ async def test_list_sources_tool(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_add_source_url_tool(monkeypatch):
-    server, client = _management_server(monkeypatch)
-    request = server_module.AddSourceUrlRequest(
+    server, client = _server_with_client(monkeypatch, client_cls=ManagementClient)
+    result = await server.app.tools["add_source_url"](
         notebook_id="nb1", url="https://example.com"
     )
-    result = await server.app.tools["add_source_url"](request)
     assert result["source"] == SRC_OBJ
     assert client.management_calls == [("add_source_url", "nb1", "https://example.com")]
 
 
 @pytest.mark.asyncio
 async def test_add_source_text_tool(monkeypatch):
-    server, client = _management_server(monkeypatch)
-    request = server_module.AddSourceTextRequest(
+    server, client = _server_with_client(monkeypatch, client_cls=ManagementClient)
+    result = await server.app.tools["add_source_text"](
         notebook_id="nb1", title="T", text="body"
     )
-    result = await server.app.tools["add_source_text"](request)
     assert result["source"] == SRC_OBJ
     assert client.management_calls == [("add_source_text", "nb1", "T", "body")]
 
 
 @pytest.mark.asyncio
 async def test_delete_source_tool(monkeypatch):
-    server, client = _management_server(monkeypatch)
-    request = server_module.DeleteSourceRequest(notebook_id="nb1", source_id="s1")
-    result = await server.app.tools["delete_source"](request)
+    server, client = _server_with_client(monkeypatch, client_cls=ManagementClient)
+    result = await server.app.tools["delete_source"](notebook_id="nb1", source_id="s1")
     assert result["status"] == "success"
     assert result["notebook_id"] == "nb1"
     assert result["source_id"] == "s1"
@@ -821,6 +712,6 @@ async def test_management_tool_wraps_client_error(monkeypatch):
         async def list_notebooks(self):
             raise RuntimeError("rpc down")
 
-    server, _ = _management_server(monkeypatch, client_cls=FailingMgmt)
+    server, _ = _server_with_client(monkeypatch, client_cls=FailingMgmt)
     with pytest.raises(NotebookLMError, match="Failed to list notebooks"):
         await server.app.tools["list_notebooks"]()


### PR DESCRIPTION
Replaces 11 Pydantic request models with plain typed tool params (FastMCP emits a flat per-tool schema — cleaner for clients, -114 LOC in server.py), and removes dead code (supports_management flag, vestigial get_response args, healthcheck try/except). Verified live against a real account. 136 tests pass; ruff/black/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)