### PR TITLE
Add source compose: merge sources across notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ notebooklm-mcp -c notebooklm-config.json server          # MCP server (stdio | h
 notebooklm-mcp -c notebooklm-config.json chat -m "..."   # quick chat from the CLI
 ```
 
-## Tools (16)
+## Tools (18)
 
 - **Chat:** `send_chat_message`, `get_chat_response`, `chat_with_notebook`, `navigate_to_notebook`, `get`/`set_default_notebook`, `healthcheck`
 - **Manage:** `list`/`create`/`rename`/`delete_notebook`, `get_notebook_summary`, `list_sources`, `add_source_url`/`add_source_text`/`delete_source`
+- **Compose:** `copy_source`, `create_notebook_from_sources` (merge sources across notebooks)
 
 MIT License

--- a/src/notebooklm_mcp/client_rpc.py
+++ b/src/notebooklm_mcp/client_rpc.py
@@ -202,6 +202,56 @@ class NotebookLMRPCClient:
         await backend.sources.delete(notebook_id, source_id)
 
     # ------------------------------------------------------------------ #
+    # Compose: copy/merge sources across notebooks
+    # ------------------------------------------------------------------ #
+    async def copy_source(
+        self, from_notebook_id: str, source_id: str, to_notebook_id: str
+    ) -> Dict[str, Any]:
+        """Copy one source into another notebook.
+
+        Web sources (which carry a ``url``) are re-added by URL; sources without
+        a URL (e.g. pasted text or uploads) are re-added as text from their
+        extracted full-text content.
+        """
+        backend = self._require_backend()
+        src = await backend.sources.get(from_notebook_id, source_id)
+        if src is None:
+            raise NavigationError(
+                f"Source {source_id} not found in notebook {from_notebook_id}"
+            )
+        url = getattr(src, "url", None)
+        if url:
+            new = await backend.sources.add_url(to_notebook_id, url)
+        else:
+            full = await backend.sources.get_fulltext(from_notebook_id, source_id)
+            title = getattr(src, "title", None) or getattr(full, "title", "Untitled")
+            content = getattr(full, "content", "") or ""
+            new = await backend.sources.add_text(to_notebook_id, title, content)
+        return _source_dict(new)
+
+    async def create_notebook_from_sources(
+        self, title: str, source_refs: List[Dict[str, str]]
+    ) -> Dict[str, Any]:
+        """Create a notebook and copy in sources picked from other notebooks.
+
+        ``source_refs`` is a list of ``{"notebook_id", "source_id"}``. Returns
+        the new notebook plus the per-source ``copied`` / ``failed`` outcome, so
+        one bad source never aborts the whole merge.
+        """
+        notebook = await self.create_notebook(title)
+        new_id = notebook["id"]
+        copied: List[Dict[str, Any]] = []
+        failed: List[Dict[str, Any]] = []
+        for ref in source_refs:
+            try:
+                copied.append(
+                    await self.copy_source(ref["notebook_id"], ref["source_id"], new_id)
+                )
+            except Exception as exc:  # noqa: BLE001 - report, don't abort the merge
+                failed.append({**ref, "error": str(exc)})
+        return {"notebook": notebook, "copied": copied, "failed": failed}
+
+    # ------------------------------------------------------------------ #
     # Helpers
     # ------------------------------------------------------------------ #
     def _require_backend(self) -> Any:

--- a/src/notebooklm_mcp/server.py
+++ b/src/notebooklm_mcp/server.py
@@ -6,16 +6,24 @@ Modern MCP server implementation using FastMCP v2 framework
 
 import asyncio
 import functools
-from typing import Any, Awaitable, Callable, Dict, Optional, TypeVar
+from typing import Any, Awaitable, Callable, Dict, List, Optional, TypeVar
 
 from fastmcp import FastMCP
 from loguru import logger
+from pydantic import BaseModel, Field
 
 from .client_rpc import NotebookLMRPCClient
 from .config import ServerConfig
 from .exceptions import NotebookLMError
 
 _T = TypeVar("_T")
+
+
+class SourceRef(BaseModel):
+    """A reference to a source living in some notebook (for copy/merge)."""
+
+    notebook_id: str = Field(..., description="Notebook that holds the source")
+    source_id: str = Field(..., description="ID of the source to copy")
 
 
 def _tool(
@@ -270,6 +278,35 @@ class NotebookLMFastMCP:
                 "notebook_id": notebook_id,
                 "source_id": source_id,
             }
+
+        @self.app.tool()
+        @_tool("Failed to copy source")
+        async def copy_source(
+            source_notebook_id: str, source_id: str, target_notebook_id: str
+        ) -> Dict[str, Any]:
+            """Copy a single source from one notebook into another."""
+            client = await self._ensure_client()
+            source = await client.copy_source(
+                source_notebook_id, source_id, target_notebook_id
+            )
+            return {"status": "success", "source": source}
+
+        @self.app.tool()
+        @_tool("Failed to create notebook from sources")
+        async def create_notebook_from_sources(
+            title: str, sources: List[SourceRef]
+        ) -> Dict[str, Any]:
+            """Create a new notebook composed of sources copied from other
+            notebooks (merge sources across notebooks).
+
+            Each item in ``sources`` is ``{notebook_id, source_id}``. Sources are
+            copied by URL when available, else by re-adding their extracted text.
+            Add more sources afterwards with ``add_source_url``/``add_source_text``.
+            """
+            client = await self._ensure_client()
+            refs = [s.model_dump() for s in sources]
+            result = await client.create_notebook_from_sources(title, refs)
+            return {"status": "success", **result}
 
     async def start(
         self, transport: str = "stdio", host: str = "127.0.0.1", port: int = 8000

--- a/tests/test_client_rpc.py
+++ b/tests/test_client_rpc.py
@@ -50,10 +50,16 @@ class _Backend:
         ask_result=None,
         list_error=None,
         ask_error=None,
+        source_get=None,
+        fulltext=None,
     ):
         self.calls: list[tuple] = []
         self._notebooks_data = list(notebooks) if notebooks is not None else []
         self._sources_data = list(sources) if sources is not None else []
+        # source_id -> Source object (for sources.get), and source_id ->
+        # SourceFulltext object (for sources.get_fulltext), used by copy_source.
+        self._source_get = dict(source_get) if source_get else {}
+        self._fulltext = dict(fulltext) if fulltext else {}
         self.summary = summary
         self.ask_result = (
             ask_result
@@ -115,6 +121,14 @@ class _SourcesAPI:
     async def delete(self, notebook_id, source_id):
         self._b.calls.append(("sources.delete", notebook_id, source_id))
         return None
+
+    async def get(self, notebook_id, source_id):
+        self._b.calls.append(("sources.get", notebook_id, source_id))
+        return self._b._source_get.get(source_id)
+
+    async def get_fulltext(self, notebook_id, source_id):
+        self._b.calls.append(("sources.get_fulltext", notebook_id, source_id))
+        return self._b._fulltext.get(source_id)
 
 
 class _ChatAPI:
@@ -628,3 +642,90 @@ def test_close_is_idempotent_without_backend(tmp_path):
     asyncio.run(client.close())
     assert client._backend is None
     assert client._cm is None
+
+
+# --------------------------------------------------------------------------- #
+# Compose: copy_source / create_notebook_from_sources
+# --------------------------------------------------------------------------- #
+def test_copy_source_with_url_readds_by_url(monkeypatch, tmp_path):
+    # A source carrying a URL is copied via sources.add_url (no fulltext needed).
+    src = SimpleNamespace(id="s1", title="Doc", url="https://example.com/p.pdf")
+    backend = _Backend(source_get={"s1": src})
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    result = asyncio.run(client.copy_source("nbA", "s1", "nbB"))
+
+    assert ("sources.get", "nbA", "s1") in backend.calls
+    assert ("sources.add_url", "nbB", "https://example.com/p.pdf") in backend.calls
+    # Must NOT fall back to fulltext when a URL is present.
+    assert not any(c[0] == "sources.get_fulltext" for c in backend.calls)
+    assert result["id"] == "src-url"
+
+
+def test_copy_source_without_url_readds_text_from_fulltext(monkeypatch, tmp_path):
+    # A URL-less source is copied by re-adding its extracted full-text content.
+    src = SimpleNamespace(id="s2", title="Note", url=None)
+    full = SimpleNamespace(title="Note", content="the body text")
+    backend = _Backend(source_get={"s2": src}, fulltext={"s2": full})
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    result = asyncio.run(client.copy_source("nbA", "s2", "nbB"))
+
+    assert ("sources.get_fulltext", "nbA", "s2") in backend.calls
+    assert ("sources.add_text", "nbB", "Note", "the body text") in backend.calls
+    assert result["id"] == "src-text"
+
+
+def test_copy_source_missing_source_raises(monkeypatch, tmp_path):
+    backend = _Backend(source_get={})  # sources.get returns None
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+    with pytest.raises(NavigationError, match="not found"):
+        asyncio.run(client.copy_source("nbA", "missing", "nbB"))
+
+
+def test_create_notebook_from_sources_copies_all(monkeypatch, tmp_path):
+    s1 = SimpleNamespace(id="s1", title="A", url="https://a.com")
+    s2 = SimpleNamespace(id="s2", title="B", url="https://b.com")
+    backend = _Backend(source_get={"s1": s1, "s2": s2})
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    result = asyncio.run(
+        client.create_notebook_from_sources(
+            "Merged",
+            [
+                {"notebook_id": "nb1", "source_id": "s1"},
+                {"notebook_id": "nb2", "source_id": "s2"},
+            ],
+        )
+    )
+
+    # A new notebook was created and both sources copied into it (nb-new).
+    assert ("notebooks.create", "Merged") in backend.calls
+    assert ("sources.add_url", "nb-new", "https://a.com") in backend.calls
+    assert ("sources.add_url", "nb-new", "https://b.com") in backend.calls
+    assert result["notebook"]["id"] == "nb-new"
+    assert len(result["copied"]) == 2
+    assert result["failed"] == []
+
+
+def test_create_notebook_from_sources_reports_partial_failure(monkeypatch, tmp_path):
+    # One good source, one missing: the merge must continue and report the bad
+    # one in `failed` rather than aborting.
+    s1 = SimpleNamespace(id="s1", title="A", url="https://a.com")
+    backend = _Backend(source_get={"s1": s1})  # "bad" not present -> raises
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    result = asyncio.run(
+        client.create_notebook_from_sources(
+            "Merged",
+            [
+                {"notebook_id": "nb1", "source_id": "s1"},
+                {"notebook_id": "nb1", "source_id": "bad"},
+            ],
+        )
+    )
+
+    assert len(result["copied"]) == 1
+    assert len(result["failed"]) == 1
+    assert result["failed"][0]["source_id"] == "bad"
+    assert "error" in result["failed"][0]


### PR DESCRIPTION
Adds two MCP tools (18 total): `copy_source` (copy one source between notebooks) and `create_notebook_from_sources` (create a notebook composed of sources picked from several notebooks — copied by URL, or by re-adding extracted text). Add more sources afterwards via the existing add_source_url/add_source_text.

Verified live against a real account: built a notebook from sources taken from two different notebooks, confirmed 2 sources landed, then cleaned up. 141 tests pass; ruff/black/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)