### PR TITLE
Add audio overview + notebook sharing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ notebooklm-mcp -c notebooklm-config.json server          # MCP server (stdio | h
 notebooklm-mcp -c notebooklm-config.json chat -m "..."   # quick chat from the CLI
 ```
 
-## Tools (18)
+## Tools (23)
 
 - **Chat:** `send_chat_message`, `get_chat_response`, `chat_with_notebook`, `navigate_to_notebook`, `get`/`set_default_notebook`, `healthcheck`
 - **Manage:** `list`/`create`/`rename`/`delete_notebook`, `get_notebook_summary`, `list_sources`, `add_source_url`/`add_source_text`/`delete_source`
 - **Compose:** `copy_source`, `create_notebook_from_sources` (merge sources across notebooks)
+- **Audio:** `generate_audio_overview`, `list_audio_overviews`
+- **Share:** `get_share_status`, `set_notebook_public`, `share_notebook_with_user`
 
 MIT License

--- a/src/notebooklm_mcp/client_rpc.py
+++ b/src/notebooklm_mcp/client_rpc.py
@@ -52,6 +52,45 @@ def _source_dict(src: Any) -> Dict[str, Any]:
     }
 
 
+def _jsonable(value: Any) -> Any:
+    """Coerce backend objects/enums into JSON-serializable values."""
+    if isinstance(value, (str, int, float, bool, type(None))):
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(v) for v in value]
+    if isinstance(value, dict):
+        return {k: _jsonable(v) for k, v in value.items()}
+    return str(value)
+
+
+def _artifact_dict(art: Any) -> Dict[str, Any]:
+    return {
+        "id": getattr(art, "id", None),
+        "title": getattr(art, "title", None),
+        "status": _jsonable(getattr(art, "status", None)),
+        "url": getattr(art, "url", None),
+    }
+
+
+def _gen_status_dict(s: Any) -> Dict[str, Any]:
+    return {
+        "task_id": getattr(s, "task_id", None),
+        "status": _jsonable(getattr(s, "status", None)),
+        "url": getattr(s, "url", None),
+        "error": getattr(s, "error", None),
+    }
+
+
+def _share_status_dict(s: Any) -> Dict[str, Any]:
+    return {
+        "notebook_id": getattr(s, "notebook_id", None),
+        "is_public": getattr(s, "is_public", None),
+        "view_level": _jsonable(getattr(s, "view_level", None)),
+        "share_url": getattr(s, "share_url", None),
+        "shared_users": _jsonable(getattr(s, "shared_users", None)),
+    }
+
+
 class NotebookLMRPCClient:
     """High-level RPC client (notebooklm-py backend) with management support."""
 
@@ -250,6 +289,56 @@ class NotebookLMRPCClient:
             except Exception as exc:  # noqa: BLE001 - report, don't abort the merge
                 failed.append({**ref, "error": str(exc)})
         return {"notebook": notebook, "copied": copied, "failed": failed}
+
+    # ------------------------------------------------------------------ #
+    # Audio Overview (podcast)
+    # ------------------------------------------------------------------ #
+    async def generate_audio_overview(
+        self,
+        notebook_id: str,
+        instructions: Optional[str] = None,
+        language: str = "en",
+    ) -> Dict[str, Any]:
+        """Request an Audio Overview (podcast). Generation runs server-side;
+        the returned status carries the task and (when ready) the audio URL."""
+        backend = self._require_backend()
+        status = await backend.artifacts.generate_audio(
+            notebook_id, language=language, instructions=instructions
+        )
+        return _gen_status_dict(status)
+
+    async def list_audio_overviews(self, notebook_id: str) -> List[Dict[str, Any]]:
+        """List the Audio Overviews generated for a notebook."""
+        backend = self._require_backend()
+        return [
+            _artifact_dict(a) for a in await backend.artifacts.list_audio(notebook_id)
+        ]
+
+    # ------------------------------------------------------------------ #
+    # Sharing
+    # ------------------------------------------------------------------ #
+    async def get_share_status(self, notebook_id: str) -> Dict[str, Any]:
+        """Read a notebook's current sharing status (read-only)."""
+        backend = self._require_backend()
+        return _share_status_dict(await backend.sharing.get_status(notebook_id))
+
+    async def set_notebook_public(
+        self, notebook_id: str, public: bool
+    ) -> Dict[str, Any]:
+        """Toggle public (link) sharing for a notebook."""
+        backend = self._require_backend()
+        return _share_status_dict(await backend.sharing.set_public(notebook_id, public))
+
+    async def share_notebook_with_user(
+        self, notebook_id: str, email: str, permission: str = "viewer"
+    ) -> Dict[str, Any]:
+        """Share a notebook with a specific person by email."""
+        from notebooklm import SharePermission
+
+        perm = getattr(SharePermission, permission.upper(), SharePermission.VIEWER)
+        backend = self._require_backend()
+        result = await backend.sharing.add_user(notebook_id, email, permission=perm)
+        return _share_status_dict(result)
 
     # ------------------------------------------------------------------ #
     # Helpers

--- a/src/notebooklm_mcp/server.py
+++ b/src/notebooklm_mcp/server.py
@@ -308,6 +308,65 @@ class NotebookLMFastMCP:
             result = await client.create_notebook_from_sources(title, refs)
             return {"status": "success", **result}
 
+        # ------------------------------------------------------------------ #
+        # Audio Overview (podcast)
+        # ------------------------------------------------------------------ #
+        @self.app.tool()
+        @_tool("Failed to generate audio overview")
+        async def generate_audio_overview(
+            notebook_id: str, instructions: Optional[str] = None, language: str = "en"
+        ) -> Dict[str, Any]:
+            """Generate an Audio Overview (podcast) for a notebook. Generation
+            runs server-side; poll with list_audio_overviews for the result."""
+            client = await self._ensure_client()
+            result = await client.generate_audio_overview(
+                notebook_id, instructions=instructions, language=language
+            )
+            return {"status": "success", "generation": result}
+
+        @self.app.tool()
+        @_tool("Failed to list audio overviews")
+        async def list_audio_overviews(notebook_id: str) -> Dict[str, Any]:
+            """List the Audio Overviews generated for a notebook."""
+            client = await self._ensure_client()
+            audios = await client.list_audio_overviews(notebook_id)
+            return {"status": "success", "count": len(audios), "audio": audios}
+
+        # ------------------------------------------------------------------ #
+        # Sharing
+        # ------------------------------------------------------------------ #
+        @self.app.tool()
+        @_tool("Failed to get share status")
+        async def get_share_status(notebook_id: str) -> Dict[str, Any]:
+            """Read a notebook's current sharing status (read-only)."""
+            client = await self._ensure_client()
+            return {
+                "status": "success",
+                "share": await client.get_share_status(notebook_id),
+            }
+
+        @self.app.tool()
+        @_tool("Failed to set notebook public")
+        async def set_notebook_public(notebook_id: str, public: bool) -> Dict[str, Any]:
+            """Toggle public (link) sharing for a notebook. Setting public=true
+            exposes the notebook to anyone with the link."""
+            client = await self._ensure_client()
+            share = await client.set_notebook_public(notebook_id, public)
+            return {"status": "success", "share": share}
+
+        @self.app.tool()
+        @_tool("Failed to share notebook")
+        async def share_notebook_with_user(
+            notebook_id: str, email: str, permission: str = "viewer"
+        ) -> Dict[str, Any]:
+            """Share a notebook with a specific person by email
+            (permission: viewer | editor)."""
+            client = await self._ensure_client()
+            share = await client.share_notebook_with_user(
+                notebook_id, email, permission=permission
+            )
+            return {"status": "success", "share": share}
+
     async def start(
         self, transport: str = "stdio", host: str = "127.0.0.1", port: int = 8000
     ) -> None:

--- a/tests/test_client_rpc.py
+++ b/tests/test_client_rpc.py
@@ -52,6 +52,9 @@ class _Backend:
         ask_error=None,
         source_get=None,
         fulltext=None,
+        audio_list=None,
+        gen_status=None,
+        share_status=None,
     ):
         self.calls: list[tuple] = []
         self._notebooks_data = list(notebooks) if notebooks is not None else []
@@ -60,6 +63,17 @@ class _Backend:
         # SourceFulltext object (for sources.get_fulltext), used by copy_source.
         self._source_get = dict(source_get) if source_get else {}
         self._fulltext = dict(fulltext) if fulltext else {}
+        self._audio_list = list(audio_list) if audio_list is not None else []
+        self._gen_status = gen_status or SimpleNamespace(
+            task_id="task-1", status="generating", url=None, error=None
+        )
+        self._share_status = share_status or SimpleNamespace(
+            notebook_id="nb1",
+            is_public=False,
+            view_level="VIEW",
+            share_url=None,
+            shared_users=[],
+        )
         self.summary = summary
         self.ask_result = (
             ask_result
@@ -71,6 +85,8 @@ class _Backend:
         self.notebooks = _NotebooksAPI(self)
         self.sources = _SourcesAPI(self)
         self.chat = _ChatAPI(self)
+        self.artifacts = _ArtifactsAPI(self)
+        self.sharing = _SharingAPI(self)
 
 
 class _NotebooksAPI:
@@ -140,6 +156,46 @@ class _ChatAPI:
         if self._b.ask_error is not None:
             raise self._b.ask_error
         return self._b.ask_result
+
+
+class _ArtifactsAPI:
+    def __init__(self, backend):
+        self._b = backend
+
+    async def generate_audio(self, notebook_id, language="en", instructions=None):
+        self._b.calls.append(
+            ("artifacts.generate_audio", notebook_id, language, instructions)
+        )
+        return self._b._gen_status
+
+    async def list_audio(self, notebook_id):
+        self._b.calls.append(("artifacts.list_audio", notebook_id))
+        return list(self._b._audio_list)
+
+
+class _SharingAPI:
+    def __init__(self, backend):
+        self._b = backend
+
+    async def get_status(self, notebook_id):
+        self._b.calls.append(("sharing.get_status", notebook_id))
+        return self._b._share_status
+
+    async def set_public(self, notebook_id, public):
+        self._b.calls.append(("sharing.set_public", notebook_id, public))
+        self._b._share_status.is_public = public
+        return self._b._share_status
+
+    async def add_user(self, notebook_id, email, permission=None):
+        self._b.calls.append(
+            (
+                "sharing.add_user",
+                notebook_id,
+                email,
+                getattr(permission, "name", permission),
+            )
+        )
+        return self._b._share_status
 
 
 class _StorageCM:
@@ -729,3 +785,96 @@ def test_create_notebook_from_sources_reports_partial_failure(monkeypatch, tmp_p
     assert len(result["failed"]) == 1
     assert result["failed"][0]["source_id"] == "bad"
     assert "error" in result["failed"][0]
+
+
+# --------------------------------------------------------------------------- #
+# Audio Overview
+# --------------------------------------------------------------------------- #
+def test_generate_audio_overview(monkeypatch, tmp_path):
+    backend = _Backend(
+        gen_status=SimpleNamespace(
+            task_id="t-9", status="generating", url=None, error=None
+        )
+    )
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    result = asyncio.run(
+        client.generate_audio_overview("nb1", instructions="be brief", language="vi")
+    )
+
+    assert ("artifacts.generate_audio", "nb1", "vi", "be brief") in backend.calls
+    assert result["task_id"] == "t-9"
+    assert result["status"] == "generating"
+
+
+def test_list_audio_overviews(monkeypatch, tmp_path):
+    art = SimpleNamespace(
+        id="a1", title="Deep Dive", status="ready", url="https://x/a1"
+    )
+    backend = _Backend(audio_list=[art])
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    audios = asyncio.run(client.list_audio_overviews("nb1"))
+
+    assert ("artifacts.list_audio", "nb1") in backend.calls
+    assert audios == [
+        {"id": "a1", "title": "Deep Dive", "status": "ready", "url": "https://x/a1"}
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# Sharing
+# --------------------------------------------------------------------------- #
+def test_get_share_status_is_read_only(monkeypatch, tmp_path):
+    status = SimpleNamespace(
+        notebook_id="nb1",
+        is_public=True,
+        view_level="VIEW",
+        share_url="https://share/nb1",
+        shared_users=[],
+    )
+    backend = _Backend(share_status=status)
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    result = asyncio.run(client.get_share_status("nb1"))
+
+    assert backend.calls[-1] == ("sharing.get_status", "nb1")
+    # Read-only: it must NOT call set_public/add_user.
+    assert not any(
+        c[0] in ("sharing.set_public", "sharing.add_user") for c in backend.calls
+    )
+    assert result["is_public"] is True
+    assert result["share_url"] == "https://share/nb1"
+
+
+def test_set_notebook_public(monkeypatch, tmp_path):
+    backend = _Backend()
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    result = asyncio.run(client.set_notebook_public("nb1", True))
+
+    assert ("sharing.set_public", "nb1", True) in backend.calls
+    assert result["is_public"] is True
+
+
+def test_share_notebook_with_user_maps_permission(monkeypatch, tmp_path):
+    backend = _Backend()
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    asyncio.run(client.share_notebook_with_user("nb1", "a@b.com", permission="editor"))
+
+    # The string permission is mapped to the SharePermission enum (EDITOR).
+    call = [c for c in backend.calls if c[0] == "sharing.add_user"][0]
+    assert call[1] == "nb1"
+    assert call[2] == "a@b.com"
+    assert call[3] == "EDITOR"
+
+
+def test_share_notebook_unknown_permission_falls_back_to_viewer(monkeypatch, tmp_path):
+    backend = _Backend()
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    asyncio.run(client.share_notebook_with_user("nb1", "a@b.com", permission="bogus"))
+
+    call = [c for c in backend.calls if c[0] == "sharing.add_user"][0]
+    assert call[3] == "VIEWER"


### PR DESCRIPTION
Adds 5 MCP tools (23 total). **Audio:** `generate_audio_overview`, `list_audio_overviews`. **Share:** `get_share_status`, `set_notebook_public`, `share_notebook_with_user`.

Verified live against a real account: generated an audio overview on a throwaway notebook (task accepted + artifact listed) and read share status, then cleaned up. The sharing WRITE paths (set_public / add_user) are unit-tested but intentionally **not** executed against real data, since they modify access controls. 147 tests pass; ruff/black/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)