### PR TITLE
Add video overview + mind map tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ notebooklm-mcp -c notebooklm-config.json server          # MCP server (stdio | h
 notebooklm-mcp -c notebooklm-config.json chat -m "..."   # quick chat from the CLI
 ```
 
-## Tools (23)
+## Tools (28)
 
 - **Chat:** `send_chat_message`, `get_chat_response`, `chat_with_notebook`, `navigate_to_notebook`, `get`/`set_default_notebook`, `healthcheck`
 - **Manage:** `list`/`create`/`rename`/`delete_notebook`, `get_notebook_summary`, `list_sources`, `add_source_url`/`add_source_text`/`delete_source`
 - **Compose:** `copy_source`, `create_notebook_from_sources` (merge sources across notebooks)
-- **Audio:** `generate_audio_overview`, `list_audio_overviews`
+- **Studio:** `generate_audio_overview`/`list_audio_overviews`, `generate_video_overview`/`list_video_overviews`, `generate_mind_map`/`list_mind_maps`/`get_mind_map`
 - **Share:** `get_share_status`, `set_notebook_public`, `share_notebook_with_user`
 
 MIT License

--- a/src/notebooklm_mcp/client_rpc.py
+++ b/src/notebooklm_mcp/client_rpc.py
@@ -81,6 +81,18 @@ def _gen_status_dict(s: Any) -> Dict[str, Any]:
     }
 
 
+def _mind_map_dict(mm: Any, include_tree: bool = False) -> Dict[str, Any]:
+    out = {
+        "id": getattr(mm, "id", None),
+        "title": getattr(mm, "title", None),
+        "kind": _jsonable(getattr(mm, "kind", None)),
+        "notebook_id": getattr(mm, "notebook_id", None),
+    }
+    if include_tree:
+        out["tree"] = _jsonable(getattr(mm, "tree", None))
+    return out
+
+
 def _share_status_dict(s: Any) -> Dict[str, Any]:
     return {
         "notebook_id": getattr(s, "notebook_id", None),
@@ -313,6 +325,66 @@ class NotebookLMRPCClient:
         return [
             _artifact_dict(a) for a in await backend.artifacts.list_audio(notebook_id)
         ]
+
+    # ------------------------------------------------------------------ #
+    # Video Overview
+    # ------------------------------------------------------------------ #
+    async def generate_video_overview(
+        self,
+        notebook_id: str,
+        instructions: Optional[str] = None,
+        language: str = "en",
+    ) -> Dict[str, Any]:
+        """Request a Video Overview. Generation runs server-side; the returned
+        status carries the task and (when ready) the video URL."""
+        backend = self._require_backend()
+        status = await backend.artifacts.generate_video(
+            notebook_id, language=language, instructions=instructions
+        )
+        return _gen_status_dict(status)
+
+    async def list_video_overviews(self, notebook_id: str) -> List[Dict[str, Any]]:
+        """List the Video Overviews generated for a notebook."""
+        backend = self._require_backend()
+        return [
+            _artifact_dict(a) for a in await backend.artifacts.list_video(notebook_id)
+        ]
+
+    # ------------------------------------------------------------------ #
+    # Mind Map
+    # ------------------------------------------------------------------ #
+    async def generate_mind_map(
+        self, notebook_id: str, kind: str = "interactive"
+    ) -> Dict[str, Any]:
+        """Generate a mind map (kind: interactive | note_backed)."""
+        from notebooklm import MindMapKind
+
+        mm_kind = getattr(MindMapKind, kind.upper(), MindMapKind.INTERACTIVE)
+        backend = self._require_backend()
+        mind_map = await backend.mind_maps.generate(notebook_id, kind=mm_kind)
+        return _mind_map_dict(mind_map)
+
+    async def list_mind_maps(self, notebook_id: str) -> List[Dict[str, Any]]:
+        """List the mind maps in a notebook."""
+        backend = self._require_backend()
+        return [_mind_map_dict(mm) for mm in await backend.mind_maps.list(notebook_id)]
+
+    async def get_mind_map(self, notebook_id: str, mind_map_id: str) -> Dict[str, Any]:
+        """Get a mind map including its node tree."""
+        backend = self._require_backend()
+        mind_map = await backend.mind_maps.get(notebook_id, mind_map_id)
+        if mind_map is None:
+            raise NavigationError(f"Mind map {mind_map_id} not found")
+        result = _mind_map_dict(mind_map, include_tree=True)
+        if result.get("tree") is None:
+            # The map object may carry no inline tree; fetch the nodes directly.
+            try:
+                result["tree"] = _jsonable(
+                    await backend.mind_maps.get_tree(notebook_id, mind_map_id)
+                )
+            except Exception as exc:  # noqa: BLE001 - tree is best-effort
+                logger.debug(f"mind map get_tree failed: {exc}")
+        return result
 
     # ------------------------------------------------------------------ #
     # Sharing

--- a/src/notebooklm_mcp/server.py
+++ b/src/notebooklm_mcp/server.py
@@ -333,6 +333,63 @@ class NotebookLMFastMCP:
             return {"status": "success", "count": len(audios), "audio": audios}
 
         # ------------------------------------------------------------------ #
+        # Video Overview
+        # ------------------------------------------------------------------ #
+        @self.app.tool()
+        @_tool("Failed to generate video overview")
+        async def generate_video_overview(
+            notebook_id: str, instructions: Optional[str] = None, language: str = "en"
+        ) -> Dict[str, Any]:
+            """Generate a Video Overview for a notebook. Generation runs
+            server-side; poll with list_video_overviews for the result."""
+            client = await self._ensure_client()
+            result = await client.generate_video_overview(
+                notebook_id, instructions=instructions, language=language
+            )
+            return {"status": "success", "generation": result}
+
+        @self.app.tool()
+        @_tool("Failed to list video overviews")
+        async def list_video_overviews(notebook_id: str) -> Dict[str, Any]:
+            """List the Video Overviews generated for a notebook."""
+            client = await self._ensure_client()
+            videos = await client.list_video_overviews(notebook_id)
+            return {"status": "success", "count": len(videos), "video": videos}
+
+        # ------------------------------------------------------------------ #
+        # Mind Map
+        # ------------------------------------------------------------------ #
+        @self.app.tool()
+        @_tool("Failed to generate mind map")
+        async def generate_mind_map(
+            notebook_id: str, kind: str = "interactive"
+        ) -> Dict[str, Any]:
+            """Generate a mind map for a notebook (kind: interactive | note_backed)."""
+            client = await self._ensure_client()
+            mind_map = await client.generate_mind_map(notebook_id, kind=kind)
+            return {"status": "success", "mind_map": mind_map}
+
+        @self.app.tool()
+        @_tool("Failed to list mind maps")
+        async def list_mind_maps(notebook_id: str) -> Dict[str, Any]:
+            """List the mind maps in a notebook."""
+            client = await self._ensure_client()
+            mind_maps = await client.list_mind_maps(notebook_id)
+            return {
+                "status": "success",
+                "count": len(mind_maps),
+                "mind_maps": mind_maps,
+            }
+
+        @self.app.tool()
+        @_tool("Failed to get mind map")
+        async def get_mind_map(notebook_id: str, mind_map_id: str) -> Dict[str, Any]:
+            """Get a mind map including its node tree."""
+            client = await self._ensure_client()
+            mind_map = await client.get_mind_map(notebook_id, mind_map_id)
+            return {"status": "success", "mind_map": mind_map}
+
+        # ------------------------------------------------------------------ #
         # Sharing
         # ------------------------------------------------------------------ #
         @self.app.tool()

--- a/tests/test_client_rpc.py
+++ b/tests/test_client_rpc.py
@@ -55,6 +55,9 @@ class _Backend:
         audio_list=None,
         gen_status=None,
         share_status=None,
+        video_list=None,
+        mind_maps=None,
+        mind_map_get=None,
     ):
         self.calls: list[tuple] = []
         self._notebooks_data = list(notebooks) if notebooks is not None else []
@@ -64,6 +67,10 @@ class _Backend:
         self._source_get = dict(source_get) if source_get else {}
         self._fulltext = dict(fulltext) if fulltext else {}
         self._audio_list = list(audio_list) if audio_list is not None else []
+        self._video_list = list(video_list) if video_list is not None else []
+        self._mind_maps_data = list(mind_maps) if mind_maps is not None else []
+        self._mind_map_get = dict(mind_map_get) if mind_map_get else {}
+        self._mind_map_tree = {"nodes": ["root"]}
         self._gen_status = gen_status or SimpleNamespace(
             task_id="task-1", status="generating", url=None, error=None
         )
@@ -87,6 +94,7 @@ class _Backend:
         self.chat = _ChatAPI(self)
         self.artifacts = _ArtifactsAPI(self)
         self.sharing = _SharingAPI(self)
+        self.mind_maps = _MindMapsAPI(self)
 
 
 class _NotebooksAPI:
@@ -171,6 +179,41 @@ class _ArtifactsAPI:
     async def list_audio(self, notebook_id):
         self._b.calls.append(("artifacts.list_audio", notebook_id))
         return list(self._b._audio_list)
+
+    async def generate_video(self, notebook_id, language="en", instructions=None):
+        self._b.calls.append(
+            ("artifacts.generate_video", notebook_id, language, instructions)
+        )
+        return self._b._gen_status
+
+    async def list_video(self, notebook_id):
+        self._b.calls.append(("artifacts.list_video", notebook_id))
+        return list(self._b._video_list)
+
+
+class _MindMapsAPI:
+    def __init__(self, backend):
+        self._b = backend
+
+    async def generate(self, notebook_id, source_ids=None, *, kind, language="en"):
+        self._b.calls.append(
+            ("mind_maps.generate", notebook_id, getattr(kind, "name", kind))
+        )
+        return SimpleNamespace(
+            id="mm-new", notebook_id=notebook_id, title="Map", kind=kind, tree={}
+        )
+
+    async def list(self, notebook_id):
+        self._b.calls.append(("mind_maps.list", notebook_id))
+        return list(self._b._mind_maps_data)
+
+    async def get_tree(self, notebook_id, mind_map_id):
+        self._b.calls.append(("mind_maps.get_tree", notebook_id, mind_map_id))
+        return self._b._mind_map_tree
+
+    async def get(self, notebook_id, mind_map_id):
+        self._b.calls.append(("mind_maps.get", notebook_id, mind_map_id))
+        return self._b._mind_map_get.get(mind_map_id)
 
 
 class _SharingAPI:
@@ -878,3 +921,109 @@ def test_share_notebook_unknown_permission_falls_back_to_viewer(monkeypatch, tmp
 
     call = [c for c in backend.calls if c[0] == "sharing.add_user"][0]
     assert call[3] == "VIEWER"
+
+
+# --------------------------------------------------------------------------- #
+# Video Overview
+# --------------------------------------------------------------------------- #
+def test_generate_video_overview(monkeypatch, tmp_path):
+    backend = _Backend(
+        gen_status=SimpleNamespace(
+            task_id="v-1", status="in_progress", url=None, error=None
+        )
+    )
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    result = asyncio.run(client.generate_video_overview("nb1", language="vi"))
+
+    assert ("artifacts.generate_video", "nb1", "vi", None) in backend.calls
+    assert result["task_id"] == "v-1"
+    assert result["status"] == "in_progress"
+
+
+def test_list_video_overviews(monkeypatch, tmp_path):
+    art = SimpleNamespace(
+        id="v9", title="Explainer", status="ready", url="https://x/v9"
+    )
+    backend = _Backend(video_list=[art])
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    videos = asyncio.run(client.list_video_overviews("nb1"))
+
+    assert ("artifacts.list_video", "nb1") in backend.calls
+    assert videos == [
+        {"id": "v9", "title": "Explainer", "status": "ready", "url": "https://x/v9"}
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# Mind Map
+# --------------------------------------------------------------------------- #
+def test_generate_mind_map_maps_kind(monkeypatch, tmp_path):
+    backend = _Backend()
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    result = asyncio.run(client.generate_mind_map("nb1", kind="note_backed"))
+
+    # The string kind is mapped to the MindMapKind enum (NOTE_BACKED).
+    assert ("mind_maps.generate", "nb1", "NOTE_BACKED") in backend.calls
+    assert result["id"] == "mm-new"
+    # A bare dict (no tree) is returned for generate.
+    assert "tree" not in result
+
+
+def test_generate_mind_map_unknown_kind_falls_back_interactive(monkeypatch, tmp_path):
+    backend = _Backend()
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    asyncio.run(client.generate_mind_map("nb1", kind="bogus"))
+
+    call = [c for c in backend.calls if c[0] == "mind_maps.generate"][0]
+    assert call[2] == "INTERACTIVE"
+
+
+def test_list_mind_maps(monkeypatch, tmp_path):
+    mm = SimpleNamespace(id="mm1", notebook_id="nb1", title="M", kind="INTERACTIVE")
+    backend = _Backend(mind_maps=[mm])
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    maps = asyncio.run(client.list_mind_maps("nb1"))
+
+    assert ("mind_maps.list", "nb1") in backend.calls
+    assert maps == [
+        {"id": "mm1", "title": "M", "kind": "INTERACTIVE", "notebook_id": "nb1"}
+    ]
+
+
+def test_get_mind_map_includes_tree(monkeypatch, tmp_path):
+    mm = SimpleNamespace(
+        id="mm1", notebook_id="nb1", title="M", kind="INTERACTIVE", tree={"root": []}
+    )
+    backend = _Backend(mind_map_get={"mm1": mm})
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    result = asyncio.run(client.get_mind_map("nb1", "mm1"))
+
+    assert ("mind_maps.get", "nb1", "mm1") in backend.calls
+    assert result["tree"] == {"root": []}
+
+
+def test_get_mind_map_missing_raises(monkeypatch, tmp_path):
+    backend = _Backend(mind_map_get={})  # get returns None
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+    with pytest.raises(NavigationError, match="not found"):
+        asyncio.run(client.get_mind_map("nb1", "missing"))
+
+
+def test_get_mind_map_fetches_tree_when_absent(monkeypatch, tmp_path):
+    # When the map object has no inline tree, the client fetches it via get_tree.
+    mm = SimpleNamespace(
+        id="mm1", notebook_id="nb1", title="M", kind="INTERACTIVE", tree=None
+    )
+    backend = _Backend(mind_map_get={"mm1": mm})
+    client = asyncio.run(started_client(monkeypatch, tmp_path, backend))
+
+    result = asyncio.run(client.get_mind_map("nb1", "mm1"))
+
+    assert ("mind_maps.get_tree", "nb1", "mm1") in backend.calls
+    assert result["tree"] == {"nodes": ["root"]}


### PR DESCRIPTION
Adds 5 MCP tools (28 total). **Video:** `generate_video_overview`, `list_video_overviews`. **Mind map:** `generate_mind_map` (interactive | note_backed), `list_mind_maps`, `get_mind_map` (with node tree).

Verified live against a real account: generated a video overview and an interactive mind map on a throwaway notebook, listed/fetched them, then cleaned up. 155 tests pass; ruff/black/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)